### PR TITLE
[#019] 유저 프로필 조회 및 업데이트 추가

### DIFF
--- a/src/main/java/com/part4/team05/sb01otbooteam05/config/AppConfig.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/config/AppConfig.java
@@ -1,0 +1,14 @@
+package com.part4.team05.sb01otbooteam05.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+
+  @Bean
+  public RestTemplate restTemplate() {
+    return new RestTemplate();
+  }
+}

--- a/src/main/java/com/part4/team05/sb01otbooteam05/config/SecurityConfig.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/config/SecurityConfig.java
@@ -3,9 +3,11 @@ package com.part4.team05.sb01otbooteam05.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
@@ -15,5 +17,23 @@ public class SecurityConfig {
   @Bean
   public PasswordEncoder passwordEncoder() {
     return new BCryptPasswordEncoder();
+  }
+
+
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http
+        .csrf(csrf -> csrf.disable()) // CSRF 비활성화 (아직 시큐리티 구현 전이라)
+        .authorizeHttpRequests(auth -> auth
+            .requestMatchers(
+                "/api/users/signup",
+                "/api/users/login",
+                "/api/users/**",
+                "/swagger-ui/**",
+                "/v3/api-docs/**"
+            ).permitAll()   // 회원가입/로그인/Swagger 모두 인증 없이 허용
+            .anyRequest().permitAll() // 일단 모두 허용하여 테스트 진행 예정 (토큰 구현 전까지)
+        );
+    return http.build();
   }
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/controller/UserController.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/controller/UserController.java
@@ -1,31 +1,58 @@
 package com.part4.team05.sb01otbooteam05.domain.user.controller;
 
+import com.part4.team05.sb01otbooteam05.domain.user.dto.ProfileDto;
+import com.part4.team05.sb01otbooteam05.domain.user.dto.ProfileUpdateRequest;
 import com.part4.team05.sb01otbooteam05.domain.user.dto.UserCreateRequest;
 import com.part4.team05.sb01otbooteam05.domain.user.dto.UserDto;
 import com.part4.team05.sb01otbooteam05.domain.user.service.UserService;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/users")
+@RequestMapping("/api/users")
 public class UserController {
 
   private final UserService userService;
 
-  @PostMapping("/signup")
+  /**
+   * 회원가입
+   */
+  @PostMapping
   public ResponseEntity<UserDto> signUp(@Valid @RequestBody UserCreateRequest request) {
     UserDto user = userService.signUp(request);
     return ResponseEntity
         .status(HttpStatus.CREATED)
         .body(user);
+  }
+
+  /**
+   * 프로필 조회
+   */
+  @GetMapping("/{userId}/profiles")
+  public ResponseEntity<ProfileDto> getProfile(@PathVariable UUID userId) {
+    ProfileDto profile = userService.getProfile(userId);
+    return ResponseEntity.ok(profile);
+  }
+
+  /**
+   * 프로필 업데이트
+   */
+  @PatchMapping(value = "/{userId}/profiles", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<ProfileDto> updateProfile(
+      @PathVariable UUID userId,
+      @RequestPart(value = "request") @Valid ProfileUpdateRequest request,
+      @RequestPart(value = "image", required = false) MultipartFile image) {
+
+    ProfileDto updatedProfile = userService.updateProfile(userId, request, image);
+    return ResponseEntity.ok(updatedProfile);
   }
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/dto/ProfileDto.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/dto/ProfileDto.java
@@ -1,0 +1,62 @@
+package com.part4.team05.sb01otbooteam05.domain.user.dto;
+
+import com.part4.team05.sb01otbooteam05.domain.user.entity.User;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProfileDto {  // 외부 클래스
+
+  private UUID userId;
+  private String name;
+  private String gender;
+  private LocalDate birthDate;
+  private LocationDto location;  // 스웨거 참고시 중첩구조
+  private Integer temperatureSensitivity;
+  private String profileImageUrl;
+
+  // ProfileDto 안에 있는 내부 클래스
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  public static class LocationDto {  // 내부 클래스
+    private Double latitude;
+    private Double longitude;
+    private Integer x;
+    private Integer y;
+    private List<String> locationNames;
+  }
+
+  public static ProfileDto from(User user) {
+    LocationDto location = null;
+    if (user.getLatitude() != null && user.getLongitude() != null) {
+      location = LocationDto.builder()
+          .latitude(user.getLatitude())
+          .longitude(user.getLongitude())
+          .x(user.getLocationX())
+          .y(user.getLocationY())
+          .locationNames(user.getLocationNames())
+          .build();
+    }
+
+    return ProfileDto.builder()
+        .userId(user.getId())
+        .name(user.getName())
+        .gender(user.getGender() != null ? user.getGender().name() : null)
+        .birthDate(user.getBirthDate())
+        .location(location)
+        .temperatureSensitivity(user.getTemperatureSensitivity())
+        .profileImageUrl(user.getProfileImageUrl())
+        .build();
+  }
+}

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/dto/ProfileUpdateRequest.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/dto/ProfileUpdateRequest.java
@@ -1,0 +1,32 @@
+package com.part4.team05.sb01otbooteam05.domain.user.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import java.time.LocalDate;
+import java.util.List;
+
+
+public record ProfileUpdateRequest(
+    String name,
+
+    @Pattern(regexp = "^(MALE|FEMALE|OTHER)$")
+    String gender,
+
+    LocalDate birthDate,
+
+    LocationRequest location,  // 중첩구조
+
+    @Min(value = 0, message = "온도 민감도는 0~5 사이의 값이어야 합니다.")
+    @Max(value = 5, message = "온도 민감도는 0~5 사이의 값이어야 합니다.")
+    Integer temperatureSensitivity
+) {
+  public record LocationRequest(
+      Double latitude,
+      Double longitude,
+      Integer x,
+      Integer y,
+      List<String> locationNames
+  ) {}
+}

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/dto/UserCreateRequest.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/dto/UserCreateRequest.java
@@ -2,27 +2,20 @@ package com.part4.team05.sb01otbooteam05.domain.user.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-public class UserCreateRequest {
+public record UserCreateRequest(
+    @NotBlank(message = "이름은 필수입니다")
+    @Size(min = 1, max = 20, message = "이름은 1자 이상 20자 이하여야 합니다")
+    String name,
 
-  //프로토타입 참고 후 지정함
-  @NotBlank(message = "이름은 필수입니다")
-  @Size(min = 1, max = 20, message = "이름은 1자 이상 20자 이하여야 합니다") //프로토타입상 최대는 정해져 있지 않지만 지정함
-  private String name;
+    @NotBlank(message = "이메일을 입력하십시오")
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    String email,
 
-  @NotBlank(message = "이메일을 입력하십시오")
-  @Email(message = "올바른 이메일 형식이 아닙니다")
-  private String email;
+    @NotBlank(message = "비밀번호를 입력하십시오")
+    @Size(min = 6, message = "비밀번호는 6자 이상이어야 합니다")
+    String password
+) {
 
-  @NotBlank(message = "비밀번호를 입력하십시오")
-  @Size(min = 6, message = "비밀번호는 6자 이상이어야 합니다")
-  private String password;
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/entity/User.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/entity/User.java
@@ -69,7 +69,7 @@ public class User extends BaseEntity {
   private List<String> locationNames;
 
   @Column(name = "temperature_sensitivity")
-  @Min(value = 0, message = "온도 민감도는 0 이상이어야 합니다") //코드래빗 추천 온도만감도 추가
+  @Min(value = 0, message = "온도 민감도는 0 이상이어야 합니다") //코드래빗 추천 온도민감도 추가
   @Max(value = 5, message = "온도 민감도는 5 이하여야 합니다")
   private Integer temperatureSensitivity;
 
@@ -83,6 +83,7 @@ public class User extends BaseEntity {
   @Column(name = "password_expires_at")
   private LocalDateTime passwordExpiresAt;
 
+  //회원가입
   public static User createUser(String email, String name, String password) {
     return User.builder()
         .email(email)
@@ -94,5 +95,36 @@ public class User extends BaseEntity {
         .build();
   }
 
+  public void updateName(String name) {
+    if (name != null && !name.trim().isEmpty()) {
+      this.name = name;
+    }
+  }
+
+  public void updateGender(GenderType gender) {
+    this.gender = gender;
+  }
+
+  public void updateBirthDate(LocalDate birthDate) {
+    this.birthDate = birthDate;
+  }
+
+  public void updateLocation(Double latitude, Double longitude, Integer x, Integer y, List<String> locationNames) {
+    this.latitude = latitude;
+    this.longitude = longitude;
+    this.locationX = x;
+    this.locationY = y;
+    this.locationNames = locationNames;
+  }
+
+  public void updateTemperatureSensitivity(Integer temperatureSensitivity) {
+    if (temperatureSensitivity != null && temperatureSensitivity >= 0 && temperatureSensitivity <= 5) {
+      this.temperatureSensitivity = temperatureSensitivity;
+    }
+  }
+
+  public void updateProfileImageUrl(String profileImageUrl) {
+    this.profileImageUrl = profileImageUrl;
+  }
 
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.part4.team05.sb01otbooteam05.domain.user.repository;
 
 import com.part4.team05.sb01otbooteam05.domain.user.entity.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,4 +12,8 @@ public interface UserRepository extends JpaRepository<User, UUID> {
 
   // 이메일 중복 확인
   boolean existsByEmail(String email);
+
+  // 사용자 조회
+  Optional<User> findById(UUID userId);
+
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/service/KakaoApiService.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/service/KakaoApiService.java
@@ -1,0 +1,67 @@
+package com.part4.team05.sb01otbooteam05.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoApiService {
+
+  private final RestTemplate restTemplate;
+
+  @Value("${kakao.rest-api-key}")
+  private String kakaoApiKey;
+
+  private static final String KAKAO_API_URL = "https://dapi.kakao.com/v2/local/geo/coord2regioncode.json";
+
+  public List<String> getLocationNames(double latitude, double longitude) {
+    try {
+      String url = UriComponentsBuilder.fromHttpUrl(KAKAO_API_URL)
+          .queryParam("x", longitude)
+          .queryParam("y", latitude)
+          .toUriString();
+
+      HttpHeaders headers = new HttpHeaders();
+      headers.set("Authorization", "KakaoAK " + kakaoApiKey);
+
+      HttpEntity<String> entity = new HttpEntity<>(headers);
+
+      ResponseEntity<Map> response = restTemplate.exchange(
+          url,
+          HttpMethod.GET,
+          entity,
+          Map.class
+      );
+
+      List<String> locationNames = new ArrayList<>();
+
+      if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
+        List<Map<String, Object>> documents = (List<Map<String, Object>>) response.getBody().get("documents");
+
+        if (documents != null && !documents.isEmpty()) {
+          for (Map<String, Object> doc : documents) {
+            String regionType = (String) doc.get("region_type");
+            if ("H".equals(regionType)) { // 행정동(H)만 -> 프로토타입상 행정동만 출력되고 있어 이렇게 결정
+              locationNames.add((String) doc.get("address_name"));
+            }
+          }
+        }
+      }
+
+      return locationNames;
+
+    } catch (Exception e) {
+      log.error("카카오 API 호출 실패: latitude={}, longitude={}", latitude, longitude, e);
+      // 실패 시 빈 리스트 반환
+      return new ArrayList<>();
+    }
+  }
+}

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/service/UserService.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/service/UserService.java
@@ -5,6 +5,9 @@ import java.util.UUID;
 import com.part4.team05.sb01otbooteam05.domain.user.dto.UserCreateRequest;
 import com.part4.team05.sb01otbooteam05.domain.user.dto.UserDto;
 import com.part4.team05.sb01otbooteam05.domain.user.entity.User;
+import com.part4.team05.sb01otbooteam05.domain.user.dto.ProfileDto;
+import com.part4.team05.sb01otbooteam05.domain.user.dto.ProfileUpdateRequest;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface UserService {
 
@@ -12,4 +15,10 @@ public interface UserService {
   UserDto signUp(UserCreateRequest request);
 
   User getUserEntityByIdOrThrow(UUID userId);
+
+  // 프로필 조회
+  ProfileDto getProfile(UUID userId);
+
+  // 프로필 업데이트
+  ProfileDto updateProfile(UUID userId, ProfileUpdateRequest request, MultipartFile image);
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/service/UserServiceImpl.java
@@ -1,7 +1,13 @@
 package com.part4.team05.sb01otbooteam05.domain.user.service;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
 import java.util.UUID;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,47 +17,179 @@ import com.part4.team05.sb01otbooteam05.domain.user.dto.UserDto;
 import com.part4.team05.sb01otbooteam05.domain.user.entity.User;
 import com.part4.team05.sb01otbooteam05.domain.user.exception.UserNotFoundException;
 import com.part4.team05.sb01otbooteam05.domain.user.repository.UserRepository;
+import com.part4.team05.sb01otbooteam05.domain.user.dto.ProfileDto;
+import com.part4.team05.sb01otbooteam05.domain.user.dto.ProfileUpdateRequest;
+import com.part4.team05.sb01otbooteam05.domain.user.entity.GenderType;
+import com.part4.team05.sb01otbooteam05.domain.user.util.LccGridConverter;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
 
-	private final UserRepository userRepository;
-	private final PasswordEncoder passwordEncoder;
+  private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
+  private final KakaoApiService kakaoApiService;
 
-	@Override
-	@Transactional
-	public UserDto signUp(UserCreateRequest request) {
-		log.info("회원가입 시도: email={}", request.getEmail());
+  // 파일 업로드 경로 (프로필 이미지)
+  @Value("${file.upload-dir:uploads/profile}")
+  private String uploadDir;
 
-		// 이메일 중복 확인
-		if (userRepository.existsByEmail(request.getEmail())) {
-			throw new IllegalArgumentException("이미 사용 중인 이메일입니다"); //todo 추후 예외처리 예정
-		}
 
-		// 비밀번호 암호화
-		String encodedPassword = passwordEncoder.encode(request.getPassword());
+  /**
+   * 회원가입
+   */
+  @Override
+  @Transactional
+  public UserDto signUp(UserCreateRequest request) {
+    log.info("회원가입 시도: email={}", request.email());
 
-		// 사용자 생성 및 저장
-		User user = User.createUser(
-			request.getEmail(),
-			request.getName(),
-			encodedPassword
-		);
+    // 이메일 중복 확인
+    if (userRepository.existsByEmail(request.email())) {
+      throw new IllegalArgumentException("이미 사용 중인 이메일입니다"); //todo 추후 예외처리 예정
+    }
 
-		User savedUser = userRepository.save(user);
-		log.info("회원가입 성공: userId={}, email={}", savedUser.getId(), savedUser.getEmail());
+    // 비밀번호 암호화
+    String encodedPassword = passwordEncoder.encode(request.password());
 
-		return UserDto.from(savedUser);
-	}
+    // 사용자 생성 및 저장
+    User user = User.createUser(
+        request.email(),
+        request.name(),
+        encodedPassword
+    );
+
+    User savedUser = userRepository.save(user);
+    log.info("회원가입 성공: userId={}, email={}", savedUser.getId(), savedUser.getEmail());
+
+    return UserDto.from(savedUser);
+  }
 
 	@Override
     @Transactional(readOnly = true)
 	public User getUserEntityByIdOrThrow(UUID userId) {
       return userRepository.findById(userId).orElseThrow(() -> UserNotFoundException.withId(userId));
 	}
+
+  /**
+   * 프로필 조회
+   */
+  @Override
+  @Transactional(readOnly = true)
+  public ProfileDto getProfile(UUID userId) {
+    log.info("프로필 조회: userId={}", userId);
+
+    User user = getUserEntityByIdOrThrow(userId);
+
+    return ProfileDto.from(user);
+  }
+
+  /**
+   * 프로필 업데이트
+   */
+  @Override
+  @Transactional
+  public ProfileDto updateProfile(UUID userId, ProfileUpdateRequest request, MultipartFile image) {
+    log.info("프로필 업데이트: userId={}", userId);
+
+    User user = getUserEntityByIdOrThrow(userId);
+
+    // 이름 업데이트
+    if (request.name() != null) {
+      user.updateName(request.name());
+    }
+
+    // 성별 업데이트
+    if (request.gender() != null) {
+      try {
+        GenderType genderType = GenderType.valueOf(request.gender());
+        user.updateGender(genderType);
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException("잘못된 성별 값입니다: " + request.gender());
+      }
+    }
+
+    // 생년월일 업데이트
+    if (request.birthDate() != null) {
+      user.updateBirthDate(request.birthDate());
+    }
+
+    // 위치 정보 업데이트
+    if (request.location() != null) {
+      ProfileUpdateRequest.LocationRequest loc = request.location();
+
+      // 위도,경도를 가지고 x, y 계산
+      LccGridConverter.XY gridXY = LccGridConverter.toGrid(loc.latitude(), loc.longitude());
+      log.info("위경도({},{}) → 변환 결과 x={}, y={}",
+          loc.latitude(), loc.longitude(), gridXY.x, gridXY.y);
+
+      // 카카오 API를 통해 지역명 조회
+      List<String> locationNames = kakaoApiService.getLocationNames(loc.latitude(), loc.longitude());
+      log.info("조회된 지역명 목록: {}", locationNames);
+
+      // 계산된 값들로 업데이트
+      user.updateLocation(
+          loc.latitude(),
+          loc.longitude(),
+          gridXY.x,
+          gridXY.y,
+          locationNames
+      );
+    }
+
+    // 온도 민감도 업데이트
+    if (request.temperatureSensitivity() != null) {
+      user.updateTemperatureSensitivity(request.temperatureSensitivity());
+    }
+
+    // 프로필 이미지 업데이트
+    if (image != null && !image.isEmpty()) {
+      String imageUrl = saveProfileImage(userId, image);
+      user.updateProfileImageUrl(imageUrl);
+    }
+
+    // 변경사항 저장
+    User updatedUser = userRepository.save(user);
+    log.info("프로필 업데이트 완료: userId={}", userId);
+
+    return ProfileDto.from(updatedUser);
+  }
+
+  /**
+   * 프로필 이미지를 저장하고 URL을 반환
+   */
+  private String saveProfileImage(UUID userId, MultipartFile image) {
+    try {
+      // 업로드 디렉토리 생성
+      Path uploadPath = Paths.get(uploadDir);
+      if (!Files.exists(uploadPath)) {
+        Files.createDirectories(uploadPath);
+      }
+
+      // 파일 확장자 추출
+      String originalFilename = image.getOriginalFilename();
+      String extension = "";
+      if (originalFilename != null && originalFilename.contains(".")) {
+        extension = originalFilename.substring(originalFilename.lastIndexOf("."));
+      }
+
+      // 고유한 파일명 생성 (userId + 타임스탬프 + 확장자)
+      String filename = userId.toString() + "_" + System.currentTimeMillis() + extension;
+
+      // 파일 저장
+      Path filePath = uploadPath.resolve(filename);
+      Files.copy(image.getInputStream(), filePath);
+
+      // URL 반환
+      return "/uploads/profile/" + filename;
+
+    } catch (IOException e) {
+      log.error("프로필 이미지 저장 실패: userId={}", userId, e);
+      throw new RuntimeException("프로필 이미지 저장에 실패했습니다", e);
+    }
+  }
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/util/LccGridConverter.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/util/LccGridConverter.java
@@ -1,0 +1,52 @@
+package com.part4.team05.sb01otbooteam05.domain.user.util;
+
+public class LccGridConverter {
+  // 제공받은 파일 속 좌표와 위경도 전환 코드
+  private static final double RE = 6371.00877; //지도반경
+  private static final double GRID = 5.0; //격자 간격
+  private static final double SLAT1 = 30.0; //표준위도1
+  private static final double SLAT2 = 60.0; //표준위도2
+  private static final double OLON = 126.0; //기준점 경도
+  private static final double OLAT = 38.0; //기준점 위도
+  private static final double XO = 210 / GRID; //기준점 X좌표
+  private static final double YO = 675 / GRID; //기준점 Y좌표
+
+  public static XY toGrid(double latitude, double longitude) {
+    double DEGRAD = Math.PI / 180.0;
+
+    double re = RE / GRID;
+    double slat1 = SLAT1 * DEGRAD;
+    double slat2 = SLAT2 * DEGRAD;
+    double olon = OLON * DEGRAD;
+    double olat = OLAT * DEGRAD;
+
+    double sn = Math.tan(Math.PI * 0.25 + slat2 * 0.5) / Math.tan(Math.PI * 0.25 + slat1 * 0.5);
+    sn = Math.log(Math.cos(slat1) / Math.cos(slat2)) / Math.log(sn);
+    double sf = Math.tan(Math.PI * 0.25 + slat1 * 0.5);
+    sf = Math.pow(sf, sn) * Math.cos(slat1) / sn;
+    double ro = Math.tan(Math.PI * 0.25 + olat * 0.5);
+    ro = re * sf / Math.pow(ro, sn);
+
+    double ra = Math.tan(Math.PI * 0.25 + latitude * DEGRAD * 0.5);
+    ra = re * sf / Math.pow(ra, sn);
+    double theta = longitude * DEGRAD - olon;
+    if (theta > Math.PI) theta -= 2.0 * Math.PI;
+    if (theta < -Math.PI) theta += 2.0 * Math.PI;
+    theta *= sn;
+
+    int x = (int) (ra * Math.sin(theta) + XO + 0.5);
+    int y = (int) (ro - ra * Math.cos(theta) + YO + 0.5);
+
+    return new XY(x, y);
+  }
+
+  // 결과 반환용 내부 클래스
+  public static class XY {
+    public final int x;
+    public final int y;
+    public XY(int x, int y) {
+      this.x = x;
+      this.y = y;
+    }
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,3 +43,7 @@ weather:
   api:
     serviceKey: ${WEATHER_API_KEY}
     url: ${WEATHER_API_URL}
+
+#카카오 지역명 추출 API
+kakao:
+  rest-api-key: ${KAKAO_REST_API_KEY}


### PR DESCRIPTION
## 🛰️ PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  버그 수정
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🪐 변경 사항
프로필 조회 가능하도록 추가
프로필 업데이트 가능하도록 추가 (사진은 uploads/profile 내에 저장하도록 진행함)
위경도 기반의 좌표 추출 코드 추가
위경도 기반의 카카오 api 활용한 지역명 추출 추가 

## 💬 공유사항 to 리뷰어
카카오 api상 행정동과 법정동 2가지로 추출 진행되어서 프로토타입과의 일관성을 위해 비교해본 결과 행정동을 사용하는 것으로 확인되어 행정동만 추출하도록 지정했습니당


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자 프로필 조회 및 수정 기능이 추가되었습니다. 이제 사용자는 자신의 프로필 정보를 조회하고, 이름, 성별, 생년월일, 위치, 온도 민감도, 프로필 이미지를 수정할 수 있습니다.
  * 프로필 이미지 업로드 및 변경 기능이 지원됩니다.
  * 위치 정보 입력 시 좌표 기반 행정구역명 자동 추출 기능이 추가되었습니다.

* **개선 사항**
  * 회원가입 엔드포인트가 단순화되어 `/api/users`에서 바로 가입할 수 있습니다.
  * 사용자 프로필 관련 API 엔드포인트가 추가 및 개선되었습니다.

* **설정**
  * 카카오 위치명 추출을 위한 API 키 설정이 추가되었습니다.

* **보안**
  * 테스트를 위한 임시 보안 설정이 적용되어, 모든 엔드포인트에 인증 없이 접근할 수 있습니다.

* **기타**
  * 일부 데이터 구조가 리팩토링되어, 사용자 생성 및 프로필 요청에 대한 데이터 검증이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->