### PR TITLE
[#037] 인증 관리 추가

### DIFF
--- a/src/main/java/com/part4/team05/sb01otbooteam05/Sb01OtbooTeam05Application.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/Sb01OtbooTeam05Application.java
@@ -1,13 +1,16 @@
 package com.part4.team05.sb01otbooteam05;
 
+import com.part4.team05.sb01otbooteam05.domain.auth.config.JwtProperties;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
 // @EnableBatchProcessing
+@EnableConfigurationProperties(JwtProperties.class)
 public class Sb01OtbooTeam05Application {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/part4/team05/sb01otbooteam05/config/SecurityConfig.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/config/SecurityConfig.java
@@ -32,7 +32,10 @@ public class SecurityConfig {
         // CSRF 설정 추가
         .csrf(csrf -> csrf
             .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-            .ignoringRequestMatchers("/api/auth/**", "/api/users") // 로그인/회원가입은 CSRF 제외
+            .ignoringRequestMatchers("/api/auth/**")
+            .ignoringRequestMatchers(request ->
+                "/api/users".equals(request.getRequestURI()) &&
+                    "POST".equals(request.getMethod()))  // 코드래빗 참고
         )
         .authorizeHttpRequests(auth -> auth
             .requestMatchers(HttpMethod.POST, "/api/users").permitAll()  // 회원가입만 허용하기 위한 post만 허용

--- a/src/main/java/com/part4/team05/sb01otbooteam05/config/SecurityConfig.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/config/SecurityConfig.java
@@ -44,7 +44,7 @@ public class SecurityConfig {
                 "/swagger-ui/**",
                 "/v3/api-docs/**"
             ).permitAll()
-            //            .anyRequest().permitAll() // 이거는 일시적으로 모두 접근 허용하는 것 (테스트용)
+            //.anyRequest().permitAll() // 이거는 일시적으로 모두 접근 허용하는 것 (테스트용)
             .anyRequest().authenticated() // 나머지는 토큰 필수 (다른 도메인도 인증 추가하여 구현 진행해야함!)
         )
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/part4/team05/sb01otbooteam05/config/SecurityConfig.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/config/SecurityConfig.java
@@ -3,37 +3,51 @@ package com.part4.team05.sb01otbooteam05.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import com.part4.team05.sb01otbooteam05.domain.auth.security.filter.JwtAuthenticationFilter; // 이 import 추가 필요
+
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+  private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
   @Bean
-  public PasswordEncoder passwordEncoder() {
+  public PasswordEncoder passwordEncoder() { //비밀번호 암호화
     return new BCryptPasswordEncoder();
   }
-
 
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     http
-        .csrf(csrf -> csrf.disable()) // CSRF 비활성화 (아직 시큐리티 구현 전이라)
+        // CSRF 설정 추가
+        .csrf(csrf -> csrf
+            .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+            .ignoringRequestMatchers("/api/auth/**", "/api/users") // 로그인/회원가입은 CSRF 제외
+        )
         .authorizeHttpRequests(auth -> auth
+            .requestMatchers(HttpMethod.POST, "/api/users").permitAll()  // 회원가입만 허용하기 위한 post만 허용
             .requestMatchers(
-                "/api/users/signup",
-                "/api/users/login",
-                "/api/users/**",
+                "/api/auth/sign-in",        // 로그인 허용
+                "/api/auth/refresh",       // 토큰 재발급 허용
+                "/api/auth/csrf-token",
+                "/api/auth/me",
                 "/swagger-ui/**",
                 "/v3/api-docs/**"
-            ).permitAll()   // 회원가입/로그인/Swagger 모두 인증 없이 허용
-            .anyRequest().permitAll() // 일단 모두 허용하여 테스트 진행 예정 (토큰 구현 전까지)
-        );
+            ).permitAll()
+            //            .anyRequest().permitAll() // 이거는 일시적으로 모두 접근 허용하는 것 (테스트용)
+            .anyRequest().authenticated() // 나머지는 토큰 필수 (다른 도메인도 인증 추가하여 구현 진행해야함!)
+        )
+        .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
     return http.build();
   }
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/config/JwtProperties.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/config/JwtProperties.java
@@ -1,0 +1,18 @@
+package com.part4.team05.sb01otbooteam05.domain.auth.config;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+  private final String secret;
+  private final Long accessTokenExpiration;
+  private final Long refreshTokenExpiration;
+
+  public JwtProperties(String secret, Long accessTokenExpiration, Long refreshTokenExpiration) {
+    this.secret = secret;
+    this.accessTokenExpiration = accessTokenExpiration != null ? accessTokenExpiration : 1800000L;
+    this.refreshTokenExpiration = refreshTokenExpiration != null ? refreshTokenExpiration : 604800000L;
+  }
+}

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/controller/AuthController.java
@@ -1,5 +1,119 @@
 package com.part4.team05.sb01otbooteam05.domain.auth.controller;
 
+import com.part4.team05.sb01otbooteam05.domain.auth.dto.SignInRequest;
+import com.part4.team05.sb01otbooteam05.domain.auth.dto.SignInResponse;
+import com.part4.team05.sb01otbooteam05.domain.auth.dto.TokenRefreshRequest;
+import com.part4.team05.sb01otbooteam05.domain.auth.security.CustomUserDetails;
+import com.part4.team05.sb01otbooteam05.domain.auth.service.AuthService;
+import com.part4.team05.sb01otbooteam05.domain.auth.dto.CsrfTokenDto;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
 public class AuthController {
 
+  private final AuthService authService;
+
+  /**
+   * 로그인
+   */
+  @PostMapping("/sign-in")
+  public ResponseEntity<String> signIn(@Valid @RequestBody SignInRequest request, HttpServletResponse response) {
+    SignInResponse authResponse = authService.signIn(request);
+
+    // refresh_token을 쿠키에 자동 저장
+    addRefreshTokenCookie(response, authResponse.getRefreshToken());
+
+    return ResponseEntity.ok(authResponse.getAccessToken());
+  }
+
+  /**
+   * 로그아웃
+   */
+  @PostMapping("/sign-out")
+  @PreAuthorize("isAuthenticated()")
+  public ResponseEntity<Void> signOut(HttpServletResponse response) {
+    // SecurityContextHolder에서 인증 정보 가져오기
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+    UUID userId = userDetails.getUserId();
+
+    authService.signOut(userId);
+
+    //로그아웃 시 쿠키 삭제 추가
+    Cookie refreshTokenCookie = new Cookie("refresh_token", null);
+    refreshTokenCookie.setMaxAge(0);
+    refreshTokenCookie.setPath("/");
+    response.addCookie(refreshTokenCookie);
+
+    return ResponseEntity.noContent().build();
+  }
+
+  /**
+   * 토큰 재발급 (리프레시 토큰 + 액세스 토큰 모두 새로 발급) (쿠키에 저장된 리프레시를 가지고)
+   */
+  @PostMapping("/refresh")
+  public ResponseEntity<String> refreshToken(
+      @CookieValue(name = "refresh_token") String refreshToken,
+      HttpServletResponse response) {
+
+    TokenRefreshRequest request = new TokenRefreshRequest(refreshToken);
+    SignInResponse authResponse = authService.refreshToken(request);
+    //새로운 refresh_token을 쿠키에 업데이트
+    addRefreshTokenCookie(response, authResponse.getRefreshToken());
+
+    return ResponseEntity.ok(authResponse.getAccessToken());
+  }
+
+  /**
+   * 액세스 토큰 조회 (리프레시 토큰은 그대로 유지)
+   */
+  @GetMapping("/me")
+  public ResponseEntity<String> getAccessToken(
+      @CookieValue(name = "refresh_token") String refreshToken) {
+
+    TokenRefreshRequest request = new TokenRefreshRequest(refreshToken);
+    String accessToken = authService.getAccessTokenOnly(request);
+    return ResponseEntity.ok(accessToken);
+  }
+
+  /**
+   * CSRF 토큰 조회 (신규 추가된 기능)
+   */
+  @GetMapping("/csrf-token")
+  public ResponseEntity<CsrfTokenDto> getCsrfToken(CsrfToken csrfToken) {
+    CsrfTokenDto response = CsrfTokenDto.builder()
+        .headerName(csrfToken.getHeaderName())     // 헤더명: X-XSRF-TOKEN
+        .token(csrfToken.getToken())               // 실제 토큰 값
+        .parameterName(csrfToken.getParameterName()) // 쿠키명: XSRF-TOKEN
+        .build();
+
+    return ResponseEntity.ok(response);
+  }
+
+  /**
+   * 리프레시 토큰 쿠키로 추가
+   */
+  private void addRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+    Cookie cookie = new Cookie("refresh_token", refreshToken);
+    cookie.setHttpOnly(true);
+    cookie.setSecure(false);    // 개발환경용
+    cookie.setPath("/");
+    cookie.setMaxAge(7 * 24 * 60 * 60); // 7일
+    response.addCookie(cookie);
+  }
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/controller/AuthController.java
@@ -114,6 +114,7 @@ public class AuthController {
     cookie.setSecure(false);    // 개발환경용
     cookie.setPath("/");
     cookie.setMaxAge(7 * 24 * 60 * 60); // 7일
+    // cookie.setAttribute("SameSite", "Lax");  // TODO: 추후 주석 제거 예정
     response.addCookie(cookie);
   }
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/dto/CsrfTokenDto.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/dto/CsrfTokenDto.java
@@ -1,0 +1,16 @@
+package com.part4.team05.sb01otbooteam05.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CsrfTokenDto {
+  private String headerName;      // 헤더 이름: X-XSRF-TOKEN
+  private String token;           // 실제 토큰 값
+  private String parameterName;   // 쿠키 이름: XSRF-TOKEN
+}

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/dto/SignInRequest.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/dto/SignInRequest.java
@@ -1,5 +1,13 @@
 package com.part4.team05.sb01otbooteam05.domain.auth.dto;
 
-public class SignInRequest {
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 
-}
+public record SignInRequest(
+    @NotBlank(message = "이메일은 필수입니다")
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    String email,
+
+    @NotBlank(message = "비밀번호는 필수입니다")
+    String password
+) {}

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/dto/SignInResponse.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/dto/SignInResponse.java
@@ -1,0 +1,20 @@
+package com.part4.team05.sb01otbooteam05.domain.auth.dto;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SignInResponse {
+  private String accessToken;
+  private String refreshToken;
+  private UUID userId;
+  private String email;
+  private String name;
+  private String role;
+}

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/dto/TokenRefreshRequest.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/dto/TokenRefreshRequest.java
@@ -1,0 +1,8 @@
+package com.part4.team05.sb01otbooteam05.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TokenRefreshRequest(
+    @NotBlank(message = "리프레시 토큰은 필수입니다")
+    String refreshToken
+) {}

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/dto/TokenRefreshResponse.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/dto/TokenRefreshResponse.java
@@ -1,0 +1,14 @@
+package com.part4.team05.sb01otbooteam05.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TokenRefreshResponse {
+  private String accessToken;
+}

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/entity/RefreshToken.java
@@ -17,7 +17,8 @@ import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "refresh_tokens", indexes = {
-    @Index(name = "idx_refresh_tokens_user_id", columnList = "user_id")
+    @Index(name = "idx_refresh_tokens_user_id", columnList = "user_id"),
+    @Index(name = "idx_refresh_tokens_token", columnList = "token")
 })
 @Getter
 @NoArgsConstructor
@@ -36,6 +37,16 @@ public class RefreshToken extends BaseEntity {
   private LocalDateTime expiresAt;
 
   @Column(nullable = false)
-  private Boolean revoked;
+  @Builder.Default
+  private Boolean revoked = false;
 
+  // 토큰 무효화
+  public void revoke() {
+    this.revoked = true;
+  }
+
+  // 토큰 유효성 확인
+  public boolean isValid() {
+    return !revoked && LocalDateTime.now().isBefore(expiresAt);
+  }
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/exception/InvalidTokenException.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/exception/InvalidTokenException.java
@@ -5,7 +5,7 @@ import com.part4.team05.sb01otbooteam05.exception.OtbooException;
 
 public class InvalidTokenException extends OtbooException {
 
-  public InvalidTokenException(String message) {
+  public InvalidTokenException() {
     super(ErrorCode.INVALID_TOKEN);
   }
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/exception/InvalidTokenException.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/exception/InvalidTokenException.java
@@ -1,0 +1,11 @@
+package com.part4.team05.sb01otbooteam05.domain.auth.exception;
+
+import com.part4.team05.sb01otbooteam05.exception.ErrorCode;
+import com.part4.team05.sb01otbooteam05.exception.OtbooException;
+
+public class InvalidTokenException extends OtbooException {
+
+  public InvalidTokenException(String message) {
+    super(ErrorCode.INVALID_TOKEN);
+  }
+}

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/exception/UnauthorizedException.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/exception/UnauthorizedException.java
@@ -1,0 +1,11 @@
+package com.part4.team05.sb01otbooteam05.domain.auth.exception;
+
+import com.part4.team05.sb01otbooteam05.exception.ErrorCode;
+import com.part4.team05.sb01otbooteam05.exception.OtbooException;
+
+public class UnauthorizedException extends OtbooException {
+
+  public UnauthorizedException(String message) {
+    super(ErrorCode.UNAUTHORIZED);
+  }
+}

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/exception/UnauthorizedException.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/exception/UnauthorizedException.java
@@ -5,7 +5,7 @@ import com.part4.team05.sb01otbooteam05.exception.OtbooException;
 
 public class UnauthorizedException extends OtbooException {
 
-  public UnauthorizedException(String message) {
+  public UnauthorizedException() {
     super(ErrorCode.UNAUTHORIZED);
   }
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/repository/RefreshTokenRepository.java
@@ -1,5 +1,27 @@
 package com.part4.team05.sb01otbooteam05.domain.auth.repository;
 
-public class RefreshTokenRepository {
+import com.part4.team05.sb01otbooteam05.domain.auth.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, UUID> {
+
+  // 토큰으로 조회 (사용자 정보 함께 로드)
+  @Query("SELECT rt FROM RefreshToken rt JOIN FETCH rt.user WHERE rt.token = :token")
+  Optional<RefreshToken> findByTokenWithUser(@Param("token") String token);
+
+  // 사용자의 모든 토큰 무효화
+  @Modifying
+  @Query("UPDATE RefreshToken rt SET rt.revoked = true WHERE rt.user.id = :userId")
+  void revokeAllByUserId(@Param("userId") UUID userId);
+
+  // 사용자 ID로 토큰 존재 여부 확인
+  boolean existsByUserIdAndRevokedFalse(UUID userId);
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/security/CustomUserDetails.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/security/CustomUserDetails.java
@@ -1,0 +1,55 @@
+package com.part4.team05.sb01otbooteam05.domain.auth.security;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+  private final UUID userId;
+  private final String email;
+  private final String role;
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role));
+  }
+
+  @Override
+  public String getPassword() {
+    return null; // JWT 인증에서는 비밀번호가 필요없음
+  }
+
+  @Override
+  public String getUsername() {
+    return email;
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return true;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+}

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,70 @@
+package com.part4.team05.sb01otbooteam05.domain.auth.security.filter;
+
+import com.part4.team05.sb01otbooteam05.domain.auth.security.jwt.JwtTokenProvider;
+import com.part4.team05.sb01otbooteam05.domain.auth.security.CustomUserDetails;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+  private final JwtTokenProvider jwtTokenProvider;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+
+    try {
+      String jwt = getJwtFromRequest(request);
+
+      if (StringUtils.hasText(jwt) && jwtTokenProvider.validateToken(jwt)) {
+        UUID userId = jwtTokenProvider.getUserIdFromToken(jwt);
+        String email = jwtTokenProvider.getEmailFromToken(jwt);
+        String role = jwtTokenProvider.getRoleFromToken(jwt);
+
+        CustomUserDetails userDetails = new CustomUserDetails(userId, email, role);
+
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+            userDetails,
+            null,
+            Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role))
+        );
+
+        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        log.debug("JWT 인증 성공: userId={}, email={}", userId, email);
+      }
+    } catch (Exception ex) {
+      log.error("Security Context에 사용자 인증을 설정할 수 없습니다", ex);
+    }
+
+    filterChain.doFilter(request, response);
+  }
+
+  // 요청에서 JWT 토큰 추출
+  private String getJwtFromRequest(HttpServletRequest request) {
+    String bearerToken = request.getHeader("Authorization");
+    if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+      return bearerToken.substring(7);
+    }
+    return null;
+  }
+}

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/security/filter/JwtAuthenticationFilter.java
@@ -9,7 +9,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
@@ -17,7 +16,6 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.UUID;
 
 @Slf4j
@@ -32,6 +30,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
       throws ServletException, IOException {
 
     try {
+      //수정
+      if (SecurityContextHolder.getContext().getAuthentication() != null &&
+          SecurityContextHolder.getContext().getAuthentication().isAuthenticated()) {
+        filterChain.doFilter(request, response);
+        return;
+      }
+
       String jwt = getJwtFromRequest(request);
 
       if (StringUtils.hasText(jwt) && jwtTokenProvider.validateToken(jwt)) {
@@ -44,7 +49,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
             userDetails,
             null,
-            Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role))
+            userDetails.getAuthorities()  // 코드래빗 참고
         );
 
         authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,111 @@
+package com.part4.team05.sb01otbooteam05.domain.auth.security.jwt;
+
+import com.part4.team05.sb01otbooteam05.domain.auth.config.JwtProperties;
+import com.part4.team05.sb01otbooteam05.domain.user.entity.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+  private final JwtProperties jwtProperties;
+
+  private SecretKey getSigningKey() {
+    return Keys.hmacShaKeyFor(jwtProperties.getSecret().getBytes(StandardCharsets.UTF_8));
+  }
+
+  // 액세스 토큰 생성
+  public String createAccessToken(User user) {
+    Date now = new Date();
+    Date expiryDate = new Date(now.getTime() + jwtProperties.getAccessTokenExpiration());
+
+    return Jwts.builder()
+        .subject(user.getId().toString())
+        .claim("email", user.getEmail())
+        .claim("name", user.getName())
+        .claim("role", user.getRole().name())
+        .issuedAt(now)
+        .expiration(expiryDate)
+        .signWith(getSigningKey())
+        .compact();
+  }
+
+  // 리프레시 토큰 생성
+  public String createRefreshToken() {
+    return UUID.randomUUID().toString();
+  }
+
+  // 토큰에서 사용자 ID 추출
+  public UUID getUserIdFromToken(String token) {
+    Claims claims = parseClaims(token);
+    return UUID.fromString(claims.getSubject());
+  }
+
+  // 토큰에서 사용자 이메일 추출
+  public String getEmailFromToken(String token) {
+    Claims claims = parseClaims(token);
+    return claims.get("email", String.class);
+  }
+
+  // 토큰에서 사용자 권한 추출
+  public String getRoleFromToken(String token) {
+    Claims claims = parseClaims(token);
+    return claims.get("role", String.class);
+  }
+
+  // 토큰 유효성 검증
+  public boolean validateToken(String token) {
+    try {
+      parseClaims(token);
+      return true;
+    } catch (MalformedJwtException ex) {
+      log.error("잘못된 JWT 토큰입니다", ex);
+    } catch (ExpiredJwtException ex) {
+      log.error("만료된 JWT 토큰입니다", ex);
+    } catch (UnsupportedJwtException ex) {
+      log.error("지원하지 않는 JWT 토큰입니다", ex);
+    } catch (IllegalArgumentException ex) {
+      log.error("JWT 토큰이 비어있습니다", ex);
+    }
+    return false;
+  }
+
+  // 토큰 파싱
+  private Claims parseClaims(String token) {
+    try {
+      return Jwts.parser()
+          .verifyWith(getSigningKey())
+          .build()
+          .parseSignedClaims(token)
+          .getPayload();
+    } catch (ExpiredJwtException e) {
+      return e.getClaims();
+    }
+  }
+
+  // 토큰 만료 여부 확인
+  public boolean isTokenExpired(String token) {
+    try {
+      Claims claims = parseClaims(token);
+      return claims.getExpiration().before(new Date());
+    } catch (ExpiredJwtException e) {
+      return true;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+}

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/service/AuthService.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/service/AuthService.java
@@ -1,5 +1,23 @@
 package com.part4.team05.sb01otbooteam05.domain.auth.service;
 
+import com.part4.team05.sb01otbooteam05.domain.auth.dto.SignInRequest;
+import com.part4.team05.sb01otbooteam05.domain.auth.dto.SignInResponse;
+import com.part4.team05.sb01otbooteam05.domain.auth.dto.TokenRefreshRequest;
+
+import java.util.UUID;
+
 public interface AuthService {
+
+  // 로그인
+  SignInResponse signIn(SignInRequest request);
+
+  // 로그아웃
+  void signOut(UUID userId);
+
+  // 토큰 재발급 (리프레시 토큰 + 액세스 토큰 모두)
+  SignInResponse refreshToken(TokenRefreshRequest request);
+
+  // 액세스 토큰만 조회 (리프레시 토큰 유지)
+  String getAccessTokenOnly(TokenRefreshRequest request);
 
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/service/AuthServiceImpl.java
@@ -41,16 +41,16 @@ public class AuthServiceImpl implements AuthService {
 
     // 사용자 조회
     User user = userRepository.findByEmail(request.email())
-        .orElseThrow(() -> new UnauthorizedException("이메일 또는 비밀번호가 일치하지 않습니다"));
+        .orElseThrow(() -> new UnauthorizedException());
 
     // 비밀번호 검증
     if (!passwordEncoder.matches(request.password(), user.getPassword())) {
-      throw new UnauthorizedException("이메일 또는 비밀번호가 일치하지 않습니다");
+      throw new UnauthorizedException();
     }
 
     // 계정 잠금 확인
     if (user.isLocked()) {
-      throw new UnauthorizedException("계정이 잠겨있습니다");
+      throw new UnauthorizedException();
     }
 
     // 기존 로그인된 계정이 있을 경우 강제 로그아웃 처리
@@ -109,11 +109,11 @@ public class AuthServiceImpl implements AuthService {
 
     // 리프레시 토큰 조회
     RefreshToken refreshToken = refreshTokenRepository.findByTokenWithUser(request.refreshToken())
-        .orElseThrow(() -> new InvalidTokenException("유효하지 않은 리프레시 토큰입니다"));
+        .orElseThrow(() -> new InvalidTokenException());
 
     // 토큰 유효성 확인
     if (!refreshToken.isValid()) {
-      throw new InvalidTokenException("만료되었거나 무효화된 리프레시 토큰입니다");
+      throw new InvalidTokenException();
     }
 
     User user = refreshToken.getUser();
@@ -157,11 +157,11 @@ public class AuthServiceImpl implements AuthService {
 
     // 리프레시 토큰 조회
     RefreshToken refreshToken = refreshTokenRepository.findByTokenWithUser(request.refreshToken())
-        .orElseThrow(() -> new InvalidTokenException("유효하지 않은 리프레시 토큰입니다"));
+        .orElseThrow(() -> new InvalidTokenException());
 
     // 토큰 유효성 확인
     if (!refreshToken.isValid()) {
-      throw new InvalidTokenException("만료되었거나 무효화된 리프레시 토큰입니다");
+      throw new InvalidTokenException();
     }
 
     User user = refreshToken.getUser();

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/service/AuthServiceImpl.java
@@ -1,0 +1,177 @@
+package com.part4.team05.sb01otbooteam05.domain.auth.service;
+
+import com.part4.team05.sb01otbooteam05.domain.auth.config.JwtProperties;
+import com.part4.team05.sb01otbooteam05.domain.auth.dto.SignInRequest;
+import com.part4.team05.sb01otbooteam05.domain.auth.dto.SignInResponse;
+import com.part4.team05.sb01otbooteam05.domain.auth.dto.TokenRefreshRequest;
+import com.part4.team05.sb01otbooteam05.domain.auth.entity.RefreshToken;
+import com.part4.team05.sb01otbooteam05.domain.auth.security.jwt.JwtTokenProvider;
+import com.part4.team05.sb01otbooteam05.domain.auth.exception.InvalidTokenException;
+import com.part4.team05.sb01otbooteam05.domain.auth.exception.UnauthorizedException;
+import com.part4.team05.sb01otbooteam05.domain.auth.repository.RefreshTokenRepository;
+import com.part4.team05.sb01otbooteam05.domain.user.entity.User;
+import com.part4.team05.sb01otbooteam05.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+  private final UserRepository userRepository;
+  private final RefreshTokenRepository refreshTokenRepository;
+  private final JwtTokenProvider jwtTokenProvider;
+  private final PasswordEncoder passwordEncoder;
+  private final JwtProperties jwtProperties;
+
+  /**
+   * 로그인
+   */
+  @Override
+  @Transactional
+  public SignInResponse signIn(SignInRequest request) {
+    log.info("로그인 시도: email={}", request.email());
+
+    // 사용자 조회
+    User user = userRepository.findByEmail(request.email())
+        .orElseThrow(() -> new UnauthorizedException("이메일 또는 비밀번호가 일치하지 않습니다"));
+
+    // 비밀번호 검증
+    if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+      throw new UnauthorizedException("이메일 또는 비밀번호가 일치하지 않습니다");
+    }
+
+    // 계정 잠금 확인
+    if (user.isLocked()) {
+      throw new UnauthorizedException("계정이 잠겨있습니다");
+    }
+
+    // 기존 로그인된 계정이 있을 경우 강제 로그아웃 처리
+    boolean hasExistingLogin = refreshTokenRepository.existsByUserIdAndRevokedFalse(user.getId());
+    if (hasExistingLogin) {
+      log.info("기존 로그인 세션 발견, 강제 로그아웃 처리: userId={}", user.getId());
+      refreshTokenRepository.revokeAllByUserId(user.getId());
+    }
+
+    // 토큰 생성
+    String accessToken = jwtTokenProvider.createAccessToken(user);
+    String refreshTokenValue = jwtTokenProvider.createRefreshToken();
+
+    // 리프레시 토큰 저장
+    RefreshToken refreshToken = RefreshToken.builder()
+        .user(user)
+        .token(refreshTokenValue)
+        .expiresAt(LocalDateTime.now().plusSeconds(jwtProperties.getRefreshTokenExpiration() / 1000))
+        .revoked(false)
+        .build();
+
+    refreshTokenRepository.save(refreshToken);
+
+    log.info("로그인 성공: userId={}, email={}, 강제로그아웃={}",
+        user.getId(), user.getEmail(), hasExistingLogin);
+
+    return SignInResponse.builder()
+        .accessToken(accessToken)
+        .refreshToken(refreshTokenValue)
+        .userId(user.getId())
+        .email(user.getEmail())
+        .name(user.getName())
+        .role(user.getRole().name())
+        .build();
+  }
+
+  /**
+   * 로그아웃
+   */
+  @Override
+  @Transactional
+  public void signOut(UUID userId) {
+    log.info("로그아웃: userId={}", userId);
+
+    // 해당 사용자의 모든 리프레시 토큰 무효화
+    refreshTokenRepository.revokeAllByUserId(userId);
+  }
+
+  /**
+   * 토큰 재발급 (리프레시 토큰 + 액세스 토큰 모두 재발급)
+   */
+  @Override
+  @Transactional
+  public SignInResponse refreshToken(TokenRefreshRequest request) {
+    log.info("리프레시 토큰과 액세스 토큰 모두 재발급 요청");
+
+    // 리프레시 토큰 조회
+    RefreshToken refreshToken = refreshTokenRepository.findByTokenWithUser(request.refreshToken())
+        .orElseThrow(() -> new InvalidTokenException("유효하지 않은 리프레시 토큰입니다"));
+
+    // 토큰 유효성 확인
+    if (!refreshToken.isValid()) {
+      throw new InvalidTokenException("만료되었거나 무효화된 리프레시 토큰입니다");
+    }
+
+    User user = refreshToken.getUser();
+
+    // 기존 리프레시 토큰 무효화
+    refreshToken.revoke();
+
+    // 새 토큰들 생성
+    String newAccessToken = jwtTokenProvider.createAccessToken(user);
+    String newRefreshTokenValue = jwtTokenProvider.createRefreshToken();
+
+    // 새 리프레시 토큰 DB 저장
+    RefreshToken newRefreshToken = RefreshToken.builder()
+        .user(user)
+        .token(newRefreshTokenValue)
+        .expiresAt(LocalDateTime.now().plusSeconds(jwtProperties.getRefreshTokenExpiration() / 1000))
+        .revoked(false)
+        .build();
+
+    refreshTokenRepository.save(newRefreshToken);
+
+    log.info("토큰 모두 재발급 완료: userId={}, 기존토큰무효화=true", user.getId());
+
+    return SignInResponse.builder()
+        .accessToken(newAccessToken)
+        .refreshToken(newRefreshTokenValue)
+        .userId(user.getId())
+        .email(user.getEmail())
+        .name(user.getName())
+        .role(user.getRole().name())
+        .build();
+  }
+
+  /**
+   * 액세스 토큰만 조회
+   */
+  @Override
+  @Transactional(readOnly = true)
+  public String getAccessTokenOnly(TokenRefreshRequest request) {
+    log.info("액세스 토큰만 조회 요청");
+
+    // 리프레시 토큰 조회
+    RefreshToken refreshToken = refreshTokenRepository.findByTokenWithUser(request.refreshToken())
+        .orElseThrow(() -> new InvalidTokenException("유효하지 않은 리프레시 토큰입니다"));
+
+    // 토큰 유효성 확인
+    if (!refreshToken.isValid()) {
+      throw new InvalidTokenException("만료되었거나 무효화된 리프레시 토큰입니다");
+    }
+
+    User user = refreshToken.getUser();
+
+    // 새 액세스 토큰만 생성 (리프레시 토큰은 그대로)
+    String newAccessToken = jwtTokenProvider.createAccessToken(user);
+
+    log.info("액세스 토큰 조회 완료: userId={}, 리프레시토큰유지=true", user.getId());
+
+    return newAccessToken;
+  }
+
+}

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/controller/UserController.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/controller/UserController.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -38,6 +39,7 @@ public class UserController {
    * 프로필 조회
    */
   @GetMapping("/{userId}/profiles")
+  @PreAuthorize("isAuthenticated()")
   public ResponseEntity<ProfileDto> getProfile(@PathVariable UUID userId) {
     ProfileDto profile = userService.getProfile(userId);
     return ResponseEntity.ok(profile);
@@ -47,6 +49,7 @@ public class UserController {
    * 프로필 업데이트
    */
   @PatchMapping(value = "/{userId}/profiles", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  @PreAuthorize("isAuthenticated()")
   public ResponseEntity<ProfileDto> updateProfile(
       @PathVariable UUID userId,
       @RequestPart(value = "request") @Valid ProfileUpdateRequest request,

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/dto/ProfileUpdateRequest.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/dto/ProfileUpdateRequest.java
@@ -1,6 +1,5 @@
 package com.part4.team05.sb01otbooteam05.domain.user.dto;
 
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/repository/UserRepository.java
@@ -16,4 +16,7 @@ public interface UserRepository extends JpaRepository<User, UUID> {
   // 사용자 조회
   Optional<User> findById(UUID userId);
 
+  // 이메일로 사용자 조회
+  Optional<User> findByEmail(String email);
+
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/service/UserServiceImpl.java
@@ -69,11 +69,11 @@ public class UserServiceImpl implements UserService {
     return UserDto.from(savedUser);
   }
 
-	@Override
-    @Transactional(readOnly = true)
-	public User getUserEntityByIdOrThrow(UUID userId) {
-      return userRepository.findById(userId).orElseThrow(() -> UserNotFoundException.withId(userId));
-	}
+  @Override
+  @Transactional(readOnly = true)
+  public User getUserEntityByIdOrThrow(UUID userId) {
+    return userRepository.findById(userId).orElseThrow(() -> UserNotFoundException.withId(userId));
+  }
 
   /**
    * 프로필 조회

--- a/src/main/java/com/part4/team05/sb01otbooteam05/exception/ErrorCode.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/exception/ErrorCode.java
@@ -10,6 +10,10 @@ public enum ErrorCode {
 	// User 관련 에러 코드
 	USER_NOT_FOUND("해당 유저를 찾을 수 없습니다."),
 
+	//Auth 관련 에러 코드
+	UNAUTHORIZED("인증이 필요합니다"),
+	INVALID_TOKEN("유효하지 않은 토큰입니다"),
+
 	// Feed 관련 에러 코드
 	FEED_NOT_FOUND("해당 피드를 찾을 수 없습니다."),
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,3 +47,9 @@ weather:
 #카카오 지역명 추출 API
 kakao:
   rest-api-key: ${KAKAO_REST_API_KEY}
+
+# JWT 설정 추가
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-expiration: 1800000
+  refresh-token-expiration: 604800000


### PR DESCRIPTION
## 🛰️ PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  버그 수정
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🪐 변경 사항
로그인, 로그아웃, 토큰 재발급, 엑세스 토큰 조회와 함께 추가된 요구사항인 CSRF 토큰 조회를 추가하였습니다.
또한, 인증에 맞춰 유저 부분에도 인증을 추가하였습니다.

## 💬 공유사항 to 리뷰어
우선 시큐리티를 회원가입과 로그인만 인증없이 접근으로 해놨기 때문에 포스트맨등 테스트 진행하실 때 반드시 로그인 하셔서 해당 토큰값을 넣어야 테스트가 가능하실 것 같습니다! 아마 안 넣고 테스트만 진행하시면 403 오류 뜰 것 같습니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * JWT 기반 인증 및 토큰 관리 기능이 추가되었습니다. (로그인, 로그아웃, 토큰 재발급, CSRF 토큰 발급 등)
  * 인증 관련 API 엔드포인트가 도입되었습니다.
  * JWT 및 리프레시 토큰 만료 시간, 시크릿 키 설정이 환경설정에 추가되었습니다.

* **보안 개선**
  * 인증 및 사용자 관련 API에 세분화된 CSRF 보호 및 인증 정책이 적용되었습니다.
  * 사용자 프로필 조회/수정 API에 인증이 필수로 적용되었습니다.

* **버그 수정 및 개선**
  * 인증 실패 및 토큰 오류에 대한 명확한 에러 코드가 추가되었습니다.

* **기타**
  * 일부 코드 스타일 및 리포지토리 구조가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->