### PR TITLE
[#048] 팔로우 조회 API 3종 구현

### DIFF
--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/controller/FollowController.java
@@ -2,16 +2,19 @@ package com.part4.team05.sb01otbooteam05.domain.follow.controller;
 
 import com.part4.team05.sb01otbooteam05.domain.follow.dto.FollowCreateRequest;
 import com.part4.team05.sb01otbooteam05.domain.follow.dto.FollowDto;
+import com.part4.team05.sb01otbooteam05.domain.follow.dto.FollowListResponse;
+import com.part4.team05.sb01otbooteam05.domain.follow.dto.FollowSummaryDto;
 import com.part4.team05.sb01otbooteam05.domain.follow.service.FollowService;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @Slf4j
 @RestController
@@ -27,5 +30,38 @@ public class FollowController {
 
         FollowDto result = followService.createFollow(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(result);
+    }
+
+    @GetMapping("/summary")
+    public ResponseEntity<FollowSummaryDto> getFollowSummary(
+            @RequestParam UUID userId,
+            @RequestParam UUID currentUserId // 추후 로그인 사용자에서 추출하도록 수정 예정
+    ) {
+        FollowSummaryDto result = followService.getFollowSummary(userId, currentUserId);
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/followings")
+    public FollowListResponse getFollowings(
+            @RequestParam @NotNull UUID followerId,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(required = false) UUID idAfter,
+            @RequestParam @Min(1) int limit,
+            @RequestParam(required = false) String nameLike
+    ) {
+        log.info("팔로잉 목록 조회 요청: followerId={}, limit={}, idAfter={}, nameLike={}", followerId, limit, idAfter, nameLike);
+        return followService.getFollowings(followerId, cursor, idAfter, limit, nameLike);
+    }
+
+    @GetMapping("/followers")
+    public FollowListResponse getFollowers(
+            @RequestParam @NotNull UUID followeeId,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(required = false) UUID idAfter,
+            @RequestParam @Min(1) int limit,
+            @RequestParam(required = false) String nameLike
+    ) {
+        log.info("팔로워 목록 조회 요청: followeeId={}, limit={}, idAfter={}, nameLike={}", followeeId, limit, idAfter, nameLike);
+        return followService.getFollowers(followeeId, cursor, idAfter, limit, nameLike);
     }
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/controller/FollowController.java
@@ -42,7 +42,7 @@ public class FollowController {
     }
 
     @GetMapping("/followings")
-    public FollowListResponse getFollowings(
+    public ResponseEntity<FollowListResponse> getFollowings(
             @RequestParam @NotNull UUID followerId,
             @RequestParam(required = false) String cursor,
             @RequestParam(required = false) UUID idAfter,
@@ -50,11 +50,12 @@ public class FollowController {
             @RequestParam(required = false) String nameLike
     ) {
         log.info("팔로잉 목록 조회 요청: followerId={}, idAfter={}, limit={}, nameLike={}", followerId, idAfter, limit, nameLike);
-        return followService.getFollowings(followerId, cursor, idAfter, limit, nameLike);
+        FollowListResponse response = followService.getFollowings(followerId, cursor, idAfter, limit, nameLike);
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/followers")
-    public FollowListResponse getFollowers(
+    public ResponseEntity<FollowListResponse> getFollowers(
             @RequestParam @NotNull UUID followeeId,
             @RequestParam(required = false) String cursor,
             @RequestParam(required = false) UUID idAfter,
@@ -62,6 +63,7 @@ public class FollowController {
             @RequestParam(required = false) String nameLike
     ) {
         log.info("팔로워 목록 조회 요청: followeeId={}, idAfter={}, limit={}, nameLike={}", followeeId, idAfter, limit, nameLike);
-        return followService.getFollowers(followeeId, cursor, idAfter, limit, nameLike);
+        FollowListResponse response = followService.getFollowers(followeeId, cursor, idAfter, limit, nameLike);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/controller/FollowController.java
@@ -49,7 +49,7 @@ public class FollowController {
             @RequestParam @Min(1) int limit,
             @RequestParam(required = false) String nameLike
     ) {
-        log.info("팔로잉 목록 조회 요청: followerId={}, limit={}, idAfter={}, nameLike={}", followerId, limit, idAfter, nameLike);
+        log.info("팔로잉 목록 조회 요청: followerId={}, idAfter={}, limit={}, nameLike={}", followerId, idAfter, limit, nameLike);
         return followService.getFollowings(followerId, cursor, idAfter, limit, nameLike);
     }
 
@@ -61,7 +61,7 @@ public class FollowController {
             @RequestParam @Min(1) int limit,
             @RequestParam(required = false) String nameLike
     ) {
-        log.info("팔로워 목록 조회 요청: followeeId={}, limit={}, idAfter={}, nameLike={}", followeeId, limit, idAfter, nameLike);
+        log.info("팔로워 목록 조회 요청: followeeId={}, idAfter={}, limit={}, nameLike={}", followeeId, idAfter, limit, nameLike);
         return followService.getFollowers(followeeId, cursor, idAfter, limit, nameLike);
     }
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/dto/FollowDto.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/dto/FollowDto.java
@@ -4,7 +4,7 @@ import java.util.UUID;
 
 public record FollowDto (
     UUID id,
-    UUID followee,
-    UUID follower
+    UUID followee,  // UserSummary followee,
+    UUID follower   // UserSummary follower
 ) {
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/dto/FollowDto.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/dto/FollowDto.java
@@ -1,10 +1,12 @@
 package com.part4.team05.sb01otbooteam05.domain.follow.dto;
 
+import com.part4.team05.sb01otbooteam05.domain.user.dto.UserSummary;
+
 import java.util.UUID;
 
 public record FollowDto (
-    UUID id,
-    UUID followee,  // UserSummary followee,
-    UUID follower   // UserSummary follower
+        UUID id,
+        UserSummary followee,
+        UserSummary follower
 ) {
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/dto/FollowListResponse.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/dto/FollowListResponse.java
@@ -1,0 +1,15 @@
+package com.part4.team05.sb01otbooteam05.domain.follow.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+public record FollowListResponse(
+        List<FollowDto> data,
+        String nextCursor,
+        UUID nextIdAfter,
+        boolean hasNext,
+        long totalCount,
+        String sortBy,
+        String sortDirection
+) {
+}

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/mapper/FollowMapper.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/mapper/FollowMapper.java
@@ -5,17 +5,17 @@ import com.part4.team05.sb01otbooteam05.domain.follow.dto.FollowDto;
 import com.part4.team05.sb01otbooteam05.domain.follow.entity.Follow;
 import com.part4.team05.sb01otbooteam05.domain.user.dto.UserSummary;
 import com.part4.team05.sb01otbooteam05.domain.user.entity.User;
-import com.part4.team05.sb01otbooteam05.domain.user.repository.UserRepository;
 import com.part4.team05.sb01otbooteam05.exception.ErrorCode;
 import com.part4.team05.sb01otbooteam05.exception.OtbooException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+import java.util.UUID;
+
 @Component
 @RequiredArgsConstructor
 public class FollowMapper {
-
-    private final UserRepository userRepository;
 
     public Follow toEntity(FollowCreateRequest request) {
         if(request == null || request.followerId() == null || request.followeeId() == null) {
@@ -28,15 +28,17 @@ public class FollowMapper {
         );
     }
 
-    public FollowDto toDto(Follow entity) {
+    public FollowDto toDto(Follow entity, Map<UUID, User> userMap) {
         if(entity == null) {
             throw new OtbooException(ErrorCode.INVALID_REQUEST);
         }
 
-        var follower = userRepository.findById(entity.getFollower())
-                .orElseThrow(() -> new OtbooException(ErrorCode.USER_NOT_FOUND));
-        var followee = userRepository.findById(entity.getFollowee())
-                .orElseThrow(() -> new OtbooException(ErrorCode.USER_NOT_FOUND));
+        User follower = userMap.get(entity.getFollower());
+        User followee = userMap.get(entity.getFollowee());
+
+        if(follower == null || followee == null) {
+            throw new OtbooException(ErrorCode.USER_NOT_FOUND);
+        }
 
         return new FollowDto(
                 entity.getId(),

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/mapper/FollowMapper.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/mapper/FollowMapper.java
@@ -3,6 +3,9 @@ package com.part4.team05.sb01otbooteam05.domain.follow.mapper;
 import com.part4.team05.sb01otbooteam05.domain.follow.dto.FollowCreateRequest;
 import com.part4.team05.sb01otbooteam05.domain.follow.dto.FollowDto;
 import com.part4.team05.sb01otbooteam05.domain.follow.entity.Follow;
+import com.part4.team05.sb01otbooteam05.domain.user.dto.UserSummary;
+import com.part4.team05.sb01otbooteam05.domain.user.entity.User;
+import com.part4.team05.sb01otbooteam05.domain.user.repository.UserRepository;
 import com.part4.team05.sb01otbooteam05.exception.ErrorCode;
 import com.part4.team05.sb01otbooteam05.exception.OtbooException;
 import lombok.RequiredArgsConstructor;
@@ -12,12 +15,10 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class FollowMapper {
 
-    public Follow toEntity(FollowCreateRequest request) {
-        if(request == null) {
-            throw new OtbooException(ErrorCode.INVALID_REQUEST);
-        }
+    private final UserRepository userRepository;
 
-        if(request.followerId() == null || request.followeeId() == null) {
+    public Follow toEntity(FollowCreateRequest request) {
+        if(request == null || request.followerId() == null || request.followeeId() == null) {
             throw new OtbooException(ErrorCode.INVALID_REQUEST);
         }
 
@@ -32,10 +33,23 @@ public class FollowMapper {
             throw new OtbooException(ErrorCode.INVALID_REQUEST);
         }
 
+        var follower = userRepository.findById(entity.getFollower())
+                .orElseThrow(() -> new OtbooException(ErrorCode.USER_NOT_FOUND));
+        var followee = userRepository.findById(entity.getFollowee())
+                .orElseThrow(() -> new OtbooException(ErrorCode.USER_NOT_FOUND));
+
         return new FollowDto(
                 entity.getId(),
-                entity.getFollowee(),
-                entity.getFollower()
+                toUserSummary(followee),
+                toUserSummary(follower)
+        );
+    }
+
+    private UserSummary toUserSummary(User user) {
+        return new UserSummary(
+                user.getId(),
+                user.getName(),
+                user.getProfileImageUrl()
         );
     }
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/repository/FollowRepository.java
@@ -1,6 +1,7 @@
 package com.part4.team05.sb01otbooteam05.domain.follow.repository;
 
 import com.part4.team05.sb01otbooteam05.domain.follow.entity.Follow;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -21,33 +22,35 @@ public interface FollowRepository extends JpaRepository<Follow, UUID> {
 
     // 팔로잉 목록 조회
     @Query("""
-        SELECT f
-        FROM Follow f
-        JOIN User u ON f.followee = u.id
-        WHERE f.follower = :followerId
-          AND (:idAfter IS NULL OR f.id > :idAfter)
-          AND (:nameLike IS NULL OR u.name LIKE %:nameLike%)
-        ORDER BY f.createdAt ASC
-    """)
+    SELECT f
+    FROM Follow f
+    JOIN User u ON f.followee = u.id
+    WHERE f.follower = :followerId
+      AND (:idAfter IS NULL OR f.id > :idAfter)
+      AND (:nameLike IS NULL OR u.name LIKE %:nameLike%)
+    ORDER BY f.createdAt ASC
+""")
     List<Follow> findFollowings(
             @Param("followerId") UUID followerId,
             @Param("idAfter") UUID idAfter,
-            @Param("nameLike") String nameLike
+            @Param("nameLike") String nameLike,
+            Pageable pageable
     );
 
     // 팔로워 목록 조회
     @Query("""
-        SELECT f
-        FROM Follow f
-        JOIN User u ON f.follower = u.id
-        WHERE f.followee = :followeeId
-          AND (:idAfter IS NULL OR f.id > :idAfter)
-          AND (:nameLike IS NULL OR u.name LIKE %:nameLike%)
-        ORDER BY f.createdAt ASC
-    """)
+    SELECT f
+    FROM Follow f
+    JOIN User u ON f.follower = u.id
+    WHERE f.followee = :followeeId
+      AND (:idAfter IS NULL OR f.id > :idAfter)
+      AND (:nameLike IS NULL OR u.name LIKE %:nameLike%)
+    ORDER BY f.createdAt ASC
+""")
     List<Follow> findFollowers(
             @Param("followeeId") UUID followeeId,
             @Param("idAfter") UUID idAfter,
-            @Param("nameLike") String nameLike
+            @Param("nameLike") String nameLike,
+            Pageable pageable
     );
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/repository/FollowRepository.java
@@ -10,24 +10,44 @@ import java.util.UUID;
 
 public interface FollowRepository extends JpaRepository<Follow, UUID> {
 
+    // 팔로워 수 조회
     long countByFollowee(UUID followee);
 
+    // 팔로잉 수 조회
     long countByFollower(UUID follower);
 
+    // 특정 팔로우 관계 존재 여부
     boolean existsByFollowerAndFollowee(UUID follower, UUID followee);
 
+    // 팔로잉 목록 조회
     @Query("""
-    SELECT f
-    FROM Follow f
-    WHERE f.follower = :userId
-    AND (:cursorId IS NULL OR f.id > :cursorId)
-    ORDER BY f.createdAt ASC
+        SELECT f
+        FROM Follow f
+        JOIN User u ON f.followee = u.id
+        WHERE f.follower = :followerId
+          AND (:idAfter IS NULL OR f.id > :idAfter)
+          AND (:nameLike IS NULL OR u.name LIKE %:nameLike%)
+        ORDER BY f.createdAt ASC
     """)
     List<Follow> findFollowings(
-            @Param("userId") UUID userId,
-            @Param("cursorId") UUID cursorId
+            @Param("followerId") UUID followerId,
+            @Param("idAfter") UUID idAfter,
+            @Param("nameLike") String nameLike
     );
 
-
-    List<Follow> findFollowers(UUID followeeId, UUID idAfter, int limit, String nameLike);
+    // 팔로워 목록 조회
+    @Query("""
+        SELECT f
+        FROM Follow f
+        JOIN User u ON f.follower = u.id
+        WHERE f.followee = :followeeId
+          AND (:idAfter IS NULL OR f.id > :idAfter)
+          AND (:nameLike IS NULL OR u.name LIKE %:nameLike%)
+        ORDER BY f.createdAt ASC
+    """)
+    List<Follow> findFollowers(
+            @Param("followeeId") UUID followeeId,
+            @Param("idAfter") UUID idAfter,
+            @Param("nameLike") String nameLike
+    );
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/repository/FollowRepository.java
@@ -2,7 +2,10 @@ package com.part4.team05.sb01otbooteam05.domain.follow.repository;
 
 import com.part4.team05.sb01otbooteam05.domain.follow.entity.Follow;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface FollowRepository extends JpaRepository<Follow, UUID> {
@@ -12,4 +15,19 @@ public interface FollowRepository extends JpaRepository<Follow, UUID> {
     long countByFollower(UUID follower);
 
     boolean existsByFollowerAndFollowee(UUID follower, UUID followee);
+
+    @Query("""
+    SELECT f
+    FROM Follow f
+    WHERE f.follower = :userId
+    AND (:cursorId IS NULL OR f.id > :cursorId)
+    ORDER BY f.createdAt ASC
+    """)
+    List<Follow> findFollowings(
+            @Param("userId") UUID userId,
+            @Param("cursorId") UUID cursorId
+    );
+
+
+    List<Follow> findFollowers(UUID followeeId, UUID idAfter, int limit, String nameLike);
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/service/FollowService.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/service/FollowService.java
@@ -2,6 +2,7 @@ package com.part4.team05.sb01otbooteam05.domain.follow.service;
 
 import com.part4.team05.sb01otbooteam05.domain.follow.dto.FollowCreateRequest;
 import com.part4.team05.sb01otbooteam05.domain.follow.dto.FollowDto;
+import com.part4.team05.sb01otbooteam05.domain.follow.dto.FollowListResponse;
 import com.part4.team05.sb01otbooteam05.domain.follow.dto.FollowSummaryDto;
 
 import java.util.UUID;
@@ -10,4 +11,8 @@ public interface FollowService {
     FollowDto createFollow(FollowCreateRequest request);
 
     FollowSummaryDto getFollowSummary(UUID userId, UUID currentUserId);
+
+    FollowListResponse getFollowings(UUID followerId, String cursor, UUID idAfter, int limit, String nameLike);
+
+    FollowListResponse getFollowers(UUID followerId, String cursor, UUID idAfter, int limit, String nameLike);
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/service/impl/FollowServiceImpl.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/service/impl/FollowServiceImpl.java
@@ -9,16 +9,25 @@ import com.part4.team05.sb01otbooteam05.domain.follow.exception.FollowException;
 import com.part4.team05.sb01otbooteam05.domain.follow.mapper.FollowMapper;
 import com.part4.team05.sb01otbooteam05.domain.follow.repository.FollowRepository;
 import com.part4.team05.sb01otbooteam05.domain.follow.service.FollowService;
+import com.part4.team05.sb01otbooteam05.domain.user.entity.User;
 import com.part4.team05.sb01otbooteam05.domain.user.repository.UserRepository;
 import com.part4.team05.sb01otbooteam05.exception.ErrorCode;
 import com.part4.team05.sb01otbooteam05.exception.OtbooException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.part4.team05.sb01otbooteam05.exception.ErrorCode.*;
 
@@ -69,7 +78,10 @@ public class FollowServiceImpl implements FollowService {
 
         log.info("팔로우 저장 완료: followId={}, follower={}, followee={}", saved.getId(), followerId, followeeId);
 
-        return followMapper.toDto(saved);
+        Map<UUID, User> userMap = userRepository.findAllById(List.of(followerId, followeeId)).stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
+
+        return followMapper.toDto(saved, userMap);
     }
 
     @Override
@@ -97,62 +109,81 @@ public class FollowServiceImpl implements FollowService {
     // 팔로잉 목록 조회
     @Override
     public FollowListResponse getFollowings(UUID followerId, String cursor, UUID idAfter, int limit, String nameLike) {
-        if(followerId == null || !userRepository.existsById(followerId)) {
-            log.warn("팔로잉 목록 조회 실패 - 존재하지 않는 사용자: followerId={}", followerId);
-            throw new OtbooException(ErrorCode.USER_NOT_FOUND);
-        }
-
-        log.debug("팔로잉 목록 조회 시작: followerId={}, idAfter={}, limit={}, nameLike={}", followerId, idAfter, limit, nameLike);
-
-        List<Follow> follows = followRepository.findFollowings(followerId, idAfter, nameLike);
-        boolean hasNext = follows.size() > limit;
-        if (hasNext) follows = follows.subList(0, limit);
-
-        List<FollowDto> dtos = follows.stream()
-                .map(followMapper::toDto)
-                .toList();
-
-        UUID nextIdAfter = hasNext ? follows.get(follows.size() - 1).getId() : null;
-
-        log.info("팔로잉 조회 완료: count={}, hasNext={}", dtos.size(), hasNext);
-        
-        return new FollowListResponse(
-                dtos,
-                null,   // cursor 방식 아직 사용 안함
-                nextIdAfter,
-                hasNext,
-                0L, //  totalCount 생략 가능
-                "id",
-                "ASCENDING"
+        return getFollowList(
+                followerId,
+                "팔로잉",
+                cursor,
+                idAfter,
+                limit,
+                nameLike,
+                (id, pageable) -> followRepository.findFollowings(id, idAfter, nameLike, pageable)
         );
     }
 
     // 팔로워 목록 조회
     @Override
     public FollowListResponse getFollowers(UUID followeeId, String cursor, UUID idAfter, int limit, String nameLike) {
-        if(followeeId == null || !userRepository.existsById(followeeId)) {
-            log.warn("팔로워 목록 조회 실패 - 존재하지 않는 사용자: followeeId={}", followeeId);
+        return getFollowList(
+                followeeId,
+                "팔로워",
+                cursor,
+                idAfter,
+                limit,
+                nameLike,
+                (id, pageable) -> followRepository.findFollowers(id, idAfter, nameLike, pageable)
+        );
+    }
+
+    private FollowListResponse getFollowList(
+            UUID userId,
+            String userType,
+            String cursor,
+            UUID idAfter,
+            int limit,
+            String nameLike,
+            BiFunction<UUID, Pageable, List<Follow>> repositoryMethod
+    ) {
+        if (userId == null || !userRepository.existsById(userId)) {
+            log.warn("{} 목록 조회 실패 - 존재하지 않는 사용자: userId={}", userType, userId);
             throw new OtbooException(ErrorCode.USER_NOT_FOUND);
         }
 
-        log.debug("팔로워 목록 조회 시작: followeeId={}, idAfter={}, limit={}, nameLike={}", followeeId, idAfter, limit, nameLike);
+        log.debug("{} 목록 조회 시작: userId={}, idAfter={}, limit={}, nameLike={}", userType, userId, idAfter, limit, nameLike);
 
-        List<Follow> follows = followRepository.findFollowers(followeeId, idAfter, nameLike);
+        Pageable pageable = PageRequest.of(0, limit + 1);
+        List<Follow> follows = repositoryMethod.apply(userId, pageable);
+
         boolean hasNext = follows.size() > limit;
-        if(hasNext) follows = follows.subList(0, limit);
+        if (hasNext) follows = follows.subList(0, limit);
+
+        List<UUID> userIds = follows.stream()
+                .flatMap(f -> Stream.of(f.getFollower(), f.getFollowee()))
+                .distinct()
+                .toList();
+
+        Map<UUID, User> userMap = userRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
 
         List<FollowDto> dtos = follows.stream()
-                .map(followMapper::toDto)
+                .map(f -> followMapper.toDto(f, userMap))
                 .toList();
 
         UUID nextIdAfter = hasNext ? follows.get(follows.size() - 1).getId() : null;
 
+        long totalCount = "팔로잉".equals(userType)
+                ? followRepository.countByFollower(userId)
+                : followRepository.countByFollowee(userId);
+
+        String nextCursor = nextIdAfter != null ? nextIdAfter.toString() : "";
+
+        log.info("{} 조회 완료: count={}, hasNext={}", userType, dtos.size(), hasNext);
+
         return new FollowListResponse(
                 dtos,
-                null,
+                nextCursor,
                 nextIdAfter,
                 hasNext,
-                0L,
+                totalCount,
                 "id",
                 "ASCENDING"
         );

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/service/impl/FollowServiceImpl.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/service/impl/FollowServiceImpl.java
@@ -95,23 +95,27 @@ public class FollowServiceImpl implements FollowService {
         );
     }
 
+    // 팔로잉 목록 조회
     @Override
     public FollowListResponse getFollowings(UUID followerId, String cursor, UUID idAfter, int limit, String nameLike) {
-        log.debug("팔로잉 목록 조회 시작: followerId={}, limit={}, idAfter={}, nameLike={}", followerId, limit, idAfter, nameLike);
-
-        if(followerId == null) {
+        if(followerId == null || !userRepository.existsById(followerId)) {
+            log.warn("팔로잉 목록 조회 실패 - 존재하지 않는 사용자: followerId={}", followerId);
             throw new OtbooException(ErrorCode.USER_NOT_FOUND);
         }
 
-        List<Follow> follows = followRepository.findFollowings(followerId, idAfter, limit + 1, nameLike);
+        log.debug("팔로잉 목록 조회 시작: followerId={}, idAfter={}, limit={}, nameLike={}", followerId, idAfter, limit, nameLike);
+
+        List<Follow> follows = followRepository.findFollowings(followerId, idAfter, nameLike);
         boolean hasNext = follows.size() > limit;
-        if (hasNext) follows.remove(follows.size() - 1);
+        if (hasNext) follows = follows.subList(0, limit);
 
         List<FollowDto> dtos = follows.stream()
                 .map(followMapper::toDto)
                 .toList();
 
         UUID nextIdAfter = hasNext ? follows.get(follows.size() - 1).getId() : null;
+
+        log.info("팔로잉 조회 완료: count={}, hasNext={}", dtos.size(), hasNext);
         
         return new FollowListResponse(
                 dtos,
@@ -124,26 +128,28 @@ public class FollowServiceImpl implements FollowService {
         );
     }
 
+    // 팔로워 목록 조회
     @Override
     public FollowListResponse getFollowers(UUID followeeId, String cursor, UUID idAfter, int limit, String nameLike) {
-        log.debug("팔로워 목록 조회: followeeId={}, idAfter={}, limit={}, nameLike={}", followeeId, idAfter, limit, nameLike);
-
-        if(followeeId == null) {
+        if(followeeId == null || !userRepository.existsById(followeeId)) {
+            log.warn("팔로워 목록 조회 실패 - 존재하지 않는 사용자: followeeId={}", followeeId);
             throw new OtbooException(ErrorCode.USER_NOT_FOUND);
         }
 
-        List<Follow> follows = followRepository.findFollowers(followeeId, idAfter, limit + 1, nameLike);
-        boolean hasNext = follows.size() > limit;
-        if(hasNext) follows.remove(follows.size() - 1);
+        log.debug("팔로워 목록 조회 시작: followeeId={}, idAfter={}, limit={}, nameLike={}", followeeId, idAfter, limit, nameLike);
 
-        List<FollowDto> followDtos = follows.stream()
+        List<Follow> follows = followRepository.findFollowers(followeeId, idAfter, nameLike);
+        boolean hasNext = follows.size() > limit;
+        if(hasNext) follows = follows.subList(0, limit);
+
+        List<FollowDto> dtos = follows.stream()
                 .map(followMapper::toDto)
-                .collect(Collectors.toList());
+                .toList();
 
         UUID nextIdAfter = hasNext ? follows.get(follows.size() - 1).getId() : null;
 
         return new FollowListResponse(
-                followDtos,
+                dtos,
                 null,
                 nextIdAfter,
                 hasNext,

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/service/impl/FollowServiceImpl.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/service/impl/FollowServiceImpl.java
@@ -19,7 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import static com.part4.team05.sb01otbooteam05.exception.ErrorCode.*;
 

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/service/impl/FollowServiceImpl.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/follow/service/impl/FollowServiceImpl.java
@@ -2,6 +2,7 @@ package com.part4.team05.sb01otbooteam05.domain.follow.service.impl;
 
 import com.part4.team05.sb01otbooteam05.domain.follow.dto.FollowCreateRequest;
 import com.part4.team05.sb01otbooteam05.domain.follow.dto.FollowDto;
+import com.part4.team05.sb01otbooteam05.domain.follow.dto.FollowListResponse;
 import com.part4.team05.sb01otbooteam05.domain.follow.dto.FollowSummaryDto;
 import com.part4.team05.sb01otbooteam05.domain.follow.entity.Follow;
 import com.part4.team05.sb01otbooteam05.domain.follow.exception.FollowException;
@@ -10,12 +11,15 @@ import com.part4.team05.sb01otbooteam05.domain.follow.repository.FollowRepositor
 import com.part4.team05.sb01otbooteam05.domain.follow.service.FollowService;
 import com.part4.team05.sb01otbooteam05.domain.user.repository.UserRepository;
 import com.part4.team05.sb01otbooteam05.exception.ErrorCode;
+import com.part4.team05.sb01otbooteam05.exception.OtbooException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static com.part4.team05.sb01otbooteam05.exception.ErrorCode.*;
 
@@ -88,6 +92,64 @@ public class FollowServiceImpl implements FollowService {
                 followedByMe,
                 followedByMe ? currentUserId : null,
                 followingMe
+        );
+    }
+
+    @Override
+    public FollowListResponse getFollowings(UUID followerId, String cursor, UUID idAfter, int limit, String nameLike) {
+        log.debug("팔로잉 목록 조회 시작: followerId={}, limit={}, idAfter={}, nameLike={}", followerId, limit, idAfter, nameLike);
+
+        if(followerId == null) {
+            throw new OtbooException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        List<Follow> follows = followRepository.findFollowings(followerId, idAfter, limit + 1, nameLike);
+        boolean hasNext = follows.size() > limit;
+        if (hasNext) follows.remove(follows.size() - 1);
+
+        List<FollowDto> dtos = follows.stream()
+                .map(followMapper::toDto)
+                .toList();
+
+        UUID nextIdAfter = hasNext ? follows.get(follows.size() - 1).getId() : null;
+        
+        return new FollowListResponse(
+                dtos,
+                null,   // cursor 방식 아직 사용 안함
+                nextIdAfter,
+                hasNext,
+                0L, //  totalCount 생략 가능
+                "id",
+                "ASCENDING"
+        );
+    }
+
+    @Override
+    public FollowListResponse getFollowers(UUID followeeId, String cursor, UUID idAfter, int limit, String nameLike) {
+        log.debug("팔로워 목록 조회: followeeId={}, idAfter={}, limit={}, nameLike={}", followeeId, idAfter, limit, nameLike);
+
+        if(followeeId == null) {
+            throw new OtbooException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        List<Follow> follows = followRepository.findFollowers(followeeId, idAfter, limit + 1, nameLike);
+        boolean hasNext = follows.size() > limit;
+        if(hasNext) follows.remove(follows.size() - 1);
+
+        List<FollowDto> followDtos = follows.stream()
+                .map(followMapper::toDto)
+                .collect(Collectors.toList());
+
+        UUID nextIdAfter = hasNext ? follows.get(follows.size() - 1).getId() : null;
+
+        return new FollowListResponse(
+                followDtos,
+                null,
+                nextIdAfter,
+                hasNext,
+                0L,
+                "id",
+                "ASCENDING"
         );
     }
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/dto/UserSummary.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/dto/UserSummary.java
@@ -1,0 +1,8 @@
+package com.part4.team05.sb01otbooteam05.domain.user.dto;
+
+import java.util.UUID;
+
+public record UserSummary(UUID userId,
+                          String name,
+                          String profileImageUrl) {
+}


### PR DESCRIPTION
## 🛰️ PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  버그 수정
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🪐 변경 사항
- 팔로잉/팔로워 목록 조회 API 구현 (/api/follows/followings, /api/follows/followers)
- 사용자 정보를 담기 위한 UserSummary 클래스 생성

## 💬 공유사항 to 리뷰어
- Follow 엔티티는 User와 관계를 맺지 않고, UUID만 저장하도록 했습니다.
- 사용자 이름과 프로필 이미지를 응답에 포함하기 위해 User를 직접 조회해서 UserSummary로 만들었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 팔로우 요약 정보를 조회할 수 있는 엔드포인트가 추가되었습니다.
  * 팔로잉 및 팔로워 목록을 페이지네이션 및 이름 필터와 함께 조회할 수 있는 엔드포인트가 추가되었습니다.
  * 사용자 요약 정보(이름, 프로필 이미지 등)를 담은 `UserSummary` 데이터 구조가 도입되었습니다.

* **개선 사항**
  * 팔로우 목록에서 단순 ID 대신 사용자 요약 정보를 포함하여 더 풍부한 정보를 제공합니다.
  * 팔로우 목록 조회 시 다음 페이지 여부와 정렬 정보가 포함된 응답을 받을 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->