### PR TITLE
[#056] 유저 서비스 위치부분 업데이트 제거 및 수정

### DIFF
--- a/src/main/java/com/part4/team05/sb01otbooteam05/config/SecurityConfig.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/config/SecurityConfig.java
@@ -41,16 +41,41 @@ public class SecurityConfig {
         .csrf(csrf -> csrf
             .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
             .csrfTokenRequestHandler(requestHandler)
+            //겟요청인 애들
+            .ignoringRequestMatchers(request ->
+                "/api/clothes/attribute-defs".equals(request.getRequestURI()) && "GET".equals(request.getMethod())
+            )
+            .ignoringRequestMatchers(request ->
+                "/api/feeds".equals(request.getRequestURI()) && "GET".equals(request.getMethod())
+            )
+            .ignoringRequestMatchers(request ->
+                "/api/users".equals(request.getRequestURI()) && "GET".equals(request.getMethod())
+            )
+            .ignoringRequestMatchers(request ->
+                "/api/clothes".equals(request.getRequestURI()) && "GET".equals(request.getMethod())
+            )
             .ignoringRequestMatchers(
                 "/api/auth/sign-in",      // 로그인 (초기 인증이므로 CSRF 토큰이 없음)
                 "/api/auth/refresh",      // 토큰 재발급
-                "/api/auth/me",          // 토큰 조회 (GET 요청이므로 제외)
+                "/api/auth/me",          // 엑세스 토큰 조회
                 "/api/auth/csrf-token",  // CSRF 토큰 조회 (토큰을 받기 위한 요청이므로 제외)
                 "/api/auth/reset-password", //비번 초기화
                 "/",
                 "/index.html", // 기본 페이지 및 아이콘
                 "/assets/**",       // 프론트엔드
-                "/uploads/**" //사진
+                "/uploads/**", //사진
+                "/api/direct-messages",
+                "/api/feeds/*/comments",
+                "/api/notifications",
+                "/api/users/*/profiles",
+                "/api/follows/summary",
+                "/api/follows/followings",
+                "/api/follows/followers",
+                "/api/clothes/extractions",
+                "/api/recommendations",
+                "/api/weathers",
+                "/api/weathers/location",
+                "/api/sse"
                 //todo 옷 사진도 여기에 넣어야함!
             )
             .ignoringRequestMatchers(request ->

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/service/UserServiceImpl.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
+//import java.util.List;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -21,7 +21,7 @@ import com.part4.team05.sb01otbooteam05.domain.user.repository.UserRepository;
 import com.part4.team05.sb01otbooteam05.domain.user.dto.ProfileDto;
 import com.part4.team05.sb01otbooteam05.domain.user.dto.ProfileUpdateRequest;
 import com.part4.team05.sb01otbooteam05.domain.user.entity.GenderType;
-import com.part4.team05.sb01otbooteam05.domain.user.util.LccGridConverter;
+//import com.part4.team05.sb01otbooteam05.domain.user.util.LccGridConverter;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,7 +34,7 @@ public class UserServiceImpl implements UserService {
 
   private final UserRepository userRepository;
   private final PasswordEncoder passwordEncoder;
-  private final KakaoApiService kakaoApiService;
+//  private final KakaoApiService kakaoApiService;
 
   // 파일 업로드 경로 (프로필 이미지)
   @Value("${file.upload-dir:uploads/profile}")
@@ -119,26 +119,42 @@ public class UserServiceImpl implements UserService {
       user.updateBirthDate(request.birthDate());
     }
 
-    // 위치 정보 업데이트
+    // 위치 정보 업데이트 - 날씨 서비스에서 계산된 값을 받아서 저장
     if (request.location() != null) {
       ProfileUpdateRequest.LocationRequest loc = request.location();
 
-      // 위도,경도를 가지고 x, y 계산
-      LccGridConverter.XY gridXY = LccGridConverter.toGrid(loc.latitude(), loc.longitude());
-      log.info("위경도({},{}) → 변환 결과 x={}, y={}",
-          loc.latitude(), loc.longitude(), gridXY.x, gridXY.y);
+      // ===== 기존 계산 로직 주석처리 (제거하면 됨 일단 혹시 몰라서 냅둠) =====
+  /*
+  // 위도,경도를 가지고 x, y 계산
+  LccGridConverter.XY gridXY = LccGridConverter.toGrid(loc.latitude(), loc.longitude());
+  log.info("위경도({},{}) → 변환 결과 x={}, y={}",
+      loc.latitude(), loc.longitude(), gridXY.x, gridXY.y);
 
-      // 카카오 API를 통해 지역명 조회
-      List<String> locationNames = kakaoApiService.getLocationNames(loc.latitude(), loc.longitude());
-      log.info("조회된 지역명 목록: {}", locationNames);
+  // 카카오 API를 통해 지역명 조회
+  List<String> locationNames = kakaoApiService.getLocationNames(loc.latitude(), loc.longitude());
+  log.info("조회된 지역명 목록: {}", locationNames);
 
-      // 계산된 값들로 업데이트
+  // 계산된 값들로 업데이트
+  user.updateLocation(
+      loc.latitude(),
+      loc.longitude(),
+      gridXY.x,
+      gridXY.y,
+      locationNames
+  );
+  */
+
+      // 날씨 서비스에서 계산된 값 사용
+      log.info("프론트엔드에서 전달받은 위치 정보 저장: latitude={}, longitude={}, x={}, y={}, locationNames={}",
+          loc.latitude(), loc.longitude(), loc.x(), loc.y(), loc.locationNames());
+
+      // 날씨 서비스에서 계산되어 전달받은 값들을 그대로 저장
       user.updateLocation(
           loc.latitude(),
           loc.longitude(),
-          gridXY.x,
-          gridXY.y,
-          locationNames
+          loc.x(),
+          loc.y(),
+          loc.locationNames()
       );
     }
 


### PR DESCRIPTION
## 🛰️ PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  버그 수정
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🪐 변경 사항
GET 요청의 CSRF 예외 목록 추가
날씨와 중복으로 위치를 계산하는 부분을 주석처리 하였습니다

## 💬 공유사항 to 리뷰어
그 저희가 위치를 2곳에서 요청?할 수 있는데요 
날씨별 옷 추천 페이지에서 [현재위치로 설정],[프로필에서 설정] 이런식으로 2곳인데 프로필에서 설정 페이지에는 저장 버튼이 있어서 유저 테이블에 잘 저장이 될 수 있다는 거를 프로토타입으로 확인했으나 "날씨별 옷 추천"페이지에서는 저장 버튼이 없어서 사용자의 위치 정보를 저장할 수 없어 새로고침하거나, 다른 페이지에 갔다가 다시 돌아오는 경우 해당 정보가 날라가 다시 현재위치로 저장 버튼을 눌러야하는 불편함을 찾았습니다

이게 만일 프론트에서 일부러 일시적인 위치 확인을 위한 것이면 유지해도 좋을 것 같고 만일 차별화를 노린다면 프론트를 수정하거나 해야할 것 같습니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 일부 GET 요청 및 특정 API 경로에 대해 CSRF 보호 예외가 추가되어, 해당 엔드포인트에서의 접근성이 향상되었습니다.

* **리팩터링**
  * 사용자 위치 정보 업데이트 시 프론트엔드에서 전달받은 위치 데이터를 직접 사용하도록 변경되어, 위치 정보 처리 과정이 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->