### PR TITLE
[#064] 알림 읽음 처리 API 구현

### DIFF
--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/notification/controller/NotificationController.java
@@ -8,6 +8,7 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -43,5 +44,11 @@ public class NotificationController {
         );
 
         return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{notificationId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void markAsRead(@PathVariable UUID notificationId) {
+        notificationService.markAsRead(notificationId);
     }
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/notification/controller/NotificationController.java
@@ -48,7 +48,8 @@ public class NotificationController {
 
     @DeleteMapping("/{notificationId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void markAsRead(@PathVariable UUID notificationId) {
-        notificationService.markAsRead(notificationId);
+    public void markAsRead(@PathVariable UUID notificationId,
+                           @RequestHeader("X-USER-ID") UUID userId) {
+        notificationService.markAsRead(notificationId, userId);
     }
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/notification/entity/Notification.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/notification/entity/Notification.java
@@ -35,4 +35,8 @@ public class Notification extends BaseEntity {
 
   @Column(nullable = false)
   private UUID receiverId;
+
+  public void markAsRead() {
+    this.isRead = true;
+  }
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/notification/service/NotificationService.java
@@ -7,4 +7,6 @@ import java.util.UUID;
 
 public interface NotificationService {
     NotificationDtoCursorResponse getNotifications(User user, UUID idAfter, int limit);
+
+    void markAsRead(UUID notificationId);
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/notification/service/NotificationService.java
@@ -8,5 +8,5 @@ import java.util.UUID;
 public interface NotificationService {
     NotificationDtoCursorResponse getNotifications(User user, UUID idAfter, int limit);
 
-    void markAsRead(UUID notificationId);
+    void markAsRead(UUID notificationId, UUID userId);
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/notification/service/impl/NotificationServiceImpl.java
@@ -64,9 +64,13 @@ public class NotificationServiceImpl implements NotificationService {
 
     @Transactional
     @Override
-    public void markAsRead(UUID notificationId) {
+    public void markAsRead(UUID notificationId, UUID userId) {
         Notification notification = notificationRepository.findById(notificationId)
                 .orElseThrow(() -> new OtbooException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+        if(!notification.getReceiverId().equals(userId)) {
+            throw new OtbooException(ErrorCode.NOTIFICATION_UNAUTHORIZED);
+        }
 
         notification.markAsRead();
         log.info("알림 읽음 처리 완료: notificationId={}", notificationId);

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/notification/service/impl/NotificationServiceImpl.java
@@ -69,5 +69,6 @@ public class NotificationServiceImpl implements NotificationService {
                 .orElseThrow(() -> new OtbooException(ErrorCode.NOTIFICATION_NOT_FOUND));
 
         notification.markAsRead();
+        log.info("알림 읽음 처리 완료: notificationId={}", notificationId);
     }
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/notification/service/impl/NotificationServiceImpl.java
@@ -8,11 +8,14 @@ import com.part4.team05.sb01otbooteam05.domain.notification.mapper.NotificationM
 import com.part4.team05.sb01otbooteam05.domain.notification.repository.NotificationRepository;
 import com.part4.team05.sb01otbooteam05.domain.notification.service.NotificationService;
 import com.part4.team05.sb01otbooteam05.domain.user.entity.User;
+import com.part4.team05.sb01otbooteam05.exception.ErrorCode;
+import com.part4.team05.sb01otbooteam05.exception.OtbooException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
@@ -57,5 +60,14 @@ public class NotificationServiceImpl implements NotificationService {
                 "createdAt",
                 "DESCENDING"
         );
+    }
+
+    @Transactional
+    @Override
+    public void markAsRead(UUID notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new OtbooException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+        notification.markAsRead();
     }
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/exception/ErrorCode.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
 
     // Notification 관련 에러 코드
 	NOTIFICATION_NOT_FOUND("알림이 존재하지 않습니다."),
+	NOTIFICATION_UNAUTHORIZED("다른 사용자의 알림은 읽을 수 없습니다."),
 
 	// follow 관련 에러 코드
 	FOLLOW_SELF_NOT_ALLOWED("자기 자신을 팔로우할 수 없습니다."),


### PR DESCRIPTION
## 🛰️ PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  버그 수정
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🪐 변경 사항
- 알림 읽음 처리 API 구현
- 알림 삭제가 아닌 읽음 처리(`is_read = true`) 로직 적용

## 💬 공유사항 to 리뷰어



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 알림을 읽음 상태로 표시할 수 있는 기능이 추가되었습니다. 이제 개별 알림을 읽음으로 처리할 수 있습니다.

* **버그 수정**
  * 다른 사용자의 알림을 읽으려고 할 때 적절한 오류 메시지가 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->