### PR TITLE
[#092] 소셜 로그인 기능 엑세스 토큰 쿠키 지원 부분 추가

### DIFF
--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/controller/AuthController.java
@@ -62,6 +62,12 @@ public class AuthController {
     refreshTokenCookie.setPath("/");
     response.addCookie(refreshTokenCookie);
 
+    // access_token 쿠키도 삭제
+    Cookie accessTokenCookie = new Cookie("access_token", null);
+    accessTokenCookie.setMaxAge(0);
+    accessTokenCookie.setPath("/");
+    response.addCookie(accessTokenCookie);
+
     return ResponseEntity.noContent().build();
   }
 

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/security/filter/JwtAuthenticationFilter.java
@@ -4,6 +4,7 @@ import com.part4.team05.sb01otbooteam05.domain.auth.security.jwt.JwtTokenProvide
 import com.part4.team05.sb01otbooteam05.domain.auth.security.CustomUserDetails;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -70,10 +71,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   // 요청에서 JWT 토큰 추출
   private String getJwtFromRequest(HttpServletRequest request) {
+    //헤더에서 먼저 확인 (일반 로그인용)
     String bearerToken = request.getHeader("Authorization");
     if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
       return bearerToken.substring(7);
     }
+
+    //헤더에 없으면 쿠키에서 확인 (소셜 로그인용)
+    if (request.getCookies() != null) {
+      for (Cookie cookie : request.getCookies()) {
+        if ("access_token".equals(cookie.getName())) {
+          return cookie.getValue();
+        }
+      }
+    }
+
     return null;
   }
 }


### PR DESCRIPTION
## 🛰️ PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  버그 수정
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🪐 변경 사항
소셜 로그인 기능 엑세스 토큰 쿠키 지원 부분 추가
소셜 로그인은 일반 로그인과 다르게 헤더로 엑세스 토큰을 전달하는 것이 아니라 쿠키로 전달하도록 구현했습니다 그 이유는 소셜로그인은 리다이렉트 방식으로 헤더로 전달할 수 없는 구조라 그렇게 진행했습니다 

## 💬 공유사항 to 리뷰어


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 로그아웃 시 "access_token" 쿠키도 함께 삭제되어 보안이 강화되었습니다.

* **신규 기능**
  * JWT 토큰을 요청 헤더뿐만 아니라 "access_token" 쿠키에서도 인식할 수 있도록 개선되어, 소셜 로그인 등 다양한 인증 방식에서의 사용성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->