### PR TITLE
[#095] 소셜 로그인 잠금 기능 추가

### DIFF
--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/security/handler/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/security/handler/OAuth2AuthenticationFailureHandler.java
@@ -21,7 +21,7 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
 
   @Override
   public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
-      AuthenticationException exception) throws IOException, ServletException {
+      AuthenticationException exception) throws IOException {
 
     String errorMessage = "Social login failed";
 
@@ -35,6 +35,9 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
           break;
         case "email_used_by_other_provider":
           errorMessage = oauthException.getError().getDescription();
+          break;
+        case "account_locked":
+          errorMessage = "Account is locked";
           break;
         default:
           errorMessage = "Authentication failed";

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/service/CustomOidcUserService.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/service/CustomOidcUserService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CustomOidcUserService extends OidcUserService { //구글 로그인
 
   private final UserRepository userRepository;
@@ -79,6 +80,15 @@ public class CustomOidcUserService extends OidcUserService { //구글 로그인
 
     if (existingSocialUser.isPresent()) {
       User user = existingSocialUser.get();
+
+      // 계정 잠금 상태 체크 추가
+      if (user.isLocked()) {
+        log.warn("잠금된 계정으로 소셜 로그인 시도: userId={}, email={}", user.getId(), user.getEmail());
+        throw new OAuth2AuthenticationException(
+            new OAuth2Error("account_locked", "Account is locked", null)
+        );
+      }
+
       log.info("기존 소셜 계정으로 로그인: userId={}, email={}", user.getId(), user.getEmail());
       return user;
     }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/service/CustomOAuth2UserService.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CustomOAuth2UserService extends DefaultOAuth2UserService { //카카오 로그인
 
   private final UserRepository userRepository;
@@ -87,6 +88,15 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService { //카카
     Optional<User> existingSocialUser = userRepository.findByProviderAndProviderId(provider, providerId);
     if (existingSocialUser.isPresent()) {
       User user = existingSocialUser.get();
+
+      // 계정 잠금 상태 체크 추가
+      if (user.isLocked()) {
+        log.warn("잠금된 계정으로 소셜 로그인 시도: userId={}, email={}", user.getId(), user.getEmail());
+        throw new OAuth2AuthenticationException(
+            new OAuth2Error("account_locked", "Account is locked", null)
+        );
+      }
+
       log.info("기존 소셜 계정으로 로그인: userId={}, email={}", user.getId(), user.getEmail());
       return user;
     }


### PR DESCRIPTION
## 🛰️ PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ]  기능 추가
- [ ]  기능 삭제
- [x]  버그 수정
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🪐 변경 사항
관리자 계정에서 소셜로그인 한 사용자를 잠금 처리해도 소셜로그인 사용자가 로그인 되는 오류를 수정했습니다

## 💬 공유사항 to 리뷰어



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 소셜 로그인(OAuth2) 시 계정이 잠긴 사용자는 로그인할 수 없도록 차단되었습니다. 잠긴 계정으로 로그인 시 "계정이 잠겼습니다"라는 메시지가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->