### PR TITLE
[#107] 관리자 수정 제한 추가

### DIFF
--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/repository/UserRepository.java
@@ -29,4 +29,7 @@ public interface UserRepository extends JpaRepository<User, UUID>, JpaSpecificat
 
   // 특정 x,y(위치) 값을 가지는 유저의 id 조회
   List<User> findByLocationXAndLocationY(Integer locationX, Integer locationY);
+
+  @Query("SELECT COUNT(u) FROM User u WHERE u.role = 'ADMIN' AND u.locked = false")
+  long countActiveAdmins();
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/service/AdminServiceImpl.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/service/AdminServiceImpl.java
@@ -34,7 +34,7 @@ public class AdminServiceImpl implements AdminService {
   private final UserRepository userRepository;
   private final RefreshTokenRepository refreshTokenRepository;
 
-  // 슈퍼 어드민 판별 헬퍼 메서드 (User 엔티티 수정 없이)
+  // 슈퍼 어드민 판별 헬퍼 메서드
   private boolean isSuperAdmin(User user) {
     return "LOCAL".equals(user.getProvider()) &&
         user.getEmail() != null &&
@@ -42,11 +42,8 @@ public class AdminServiceImpl implements AdminService {
         user.getRole() == UserRole.ADMIN;
   }
 
-  // 활성 관리자 수 계산 헬퍼 메서드
   private long countActiveAdmins() {
-    return userRepository.findAll().stream()
-        .filter(user -> user.getRole() == UserRole.ADMIN && !user.isLocked())
-        .count();
+    return userRepository.countActiveAdmins();
   }
 
   // 현재 로그인한 관리자 ID 가져오기
@@ -187,7 +184,6 @@ public class AdminServiceImpl implements AdminService {
       }
     }
 
-    // 기존 로직 그대로
     targetUser.updateRole(request.role());
     User updatedUser = userRepository.save(targetUser);
 
@@ -231,7 +227,6 @@ public class AdminServiceImpl implements AdminService {
       }
     }
 
-    // 기존 로직 그대로
     targetUser.updateLocked(request.locked());
     userRepository.save(targetUser);
 

--- a/src/test/java/com/part4/team05/sb01otbooteam05/domain/user/service/AdminServiceImplTest.java
+++ b/src/test/java/com/part4/team05/sb01otbooteam05/domain/user/service/AdminServiceImplTest.java
@@ -28,7 +28,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -180,8 +179,7 @@ class AdminServiceImplTest {
 
       UserRoleUpdateRequest request = new UserRoleUpdateRequest(UserRole.USER);
       when(userRepository.findById(NORMAL_ADMIN_ID)).thenReturn(Optional.of(normalAdmin));
-      // 활성 관리자가 1명만 있다고 모킹
-      when(userRepository.findAll()).thenReturn(Arrays.asList(normalAdmin));
+      when(userRepository.countActiveAdmins()).thenReturn(1L);
 
       assertThatThrownBy(() -> adminService.updateUserRole(NORMAL_ADMIN_ID, request))
           .isInstanceOf(SecurityException.class)
@@ -257,6 +255,26 @@ class AdminServiceImplTest {
       assertThatThrownBy(() -> adminService.updateUserLockStatus(SUPER_ADMIN_ID, request))
           .isInstanceOf(SecurityException.class)
           .hasMessage("슈퍼 어드민 계정은 잠글 수 없습니다.");
+
+      verify(userRepository, never()).save(any());
+      verify(refreshTokenRepository, never()).revokeAllByUserId(any());
+    }
+  }
+
+  @Test
+  @DisplayName("계정 잠금 실패 - 마지막 활성 관리자 잠금 시도")
+  void updateUserLockStatus_LastActiveAdminLock_ThrowsException() {
+    try (MockedStatic<SecurityContextHolder> mockedSecurityContextHolder = mockStatic(SecurityContextHolder.class)) {
+      setupSecurityContext();
+      mockedSecurityContextHolder.when(SecurityContextHolder::getContext).thenReturn(securityContext);
+
+      UserLockUpdateRequest request = new UserLockUpdateRequest(true);
+      when(userRepository.findById(NORMAL_ADMIN_ID)).thenReturn(Optional.of(normalAdmin));
+      when(userRepository.countActiveAdmins()).thenReturn(1L);
+
+      assertThatThrownBy(() -> adminService.updateUserLockStatus(NORMAL_ADMIN_ID, request))
+          .isInstanceOf(SecurityException.class)
+          .hasMessage("시스템에 최소 1명의 활성 관리자가 있어야 합니다.");
 
       verify(userRepository, never()).save(any());
       verify(refreshTokenRepository, never()).revokeAllByUserId(any());


### PR DESCRIPTION
## 🛰️ PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  버그 수정
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🪐 변경 사항
최초 관리자인 admin계정을 추후 추가된 관리자가 잠글 수 있는 부분을 검증을 통해
admin 계정은 변경할 수 없고, 자기 자신은 잠금 및 역할 변경이 불가능하도록 수정하였습니다

## 💬 공유사항 to 리뷰어



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 관리자가 자신의 역할이나 잠금 상태를 변경할 수 없도록 보안 검증이 강화되었습니다.
  * 슈퍼 관리자의 역할 및 잠금 상태 변경이 차단됩니다.
  * 마지막 활성 관리자 계정의 역할 제거 및 잠금이 방지됩니다.
  * 역할 및 잠금 상태 변경 시 관련 토큰이 즉시 무효화됩니다.

* **테스트**
  * 위 보안 정책에 대한 다양한 예외 상황 테스트가 추가되었습니다.
  * 인증된 관리자 시나리오를 모의하여 테스트 신뢰성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->