### PR TITLE
[#104] 날씨도메인 리펙토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,8 @@ dependencies {
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
     implementation 'io.micrometer:micrometer-registry-prometheus' // 프로메테우스 의존성
-    implementation 'org.springframework.boot:spring-boot-starter-batch' //스프링 배치
+    implementation 'org.springframework.boot:spring-boot-starter-batch' //스프링 배치 스타터
+    implementation 'org.springframework.batch:spring-batch-integration' //스프링 배치 integration
     implementation 'org.springframework.boot:spring-boot-starter-mail' //임시 비밀번호 발송시 이메일 사용을 위한 의존성
     implementation "io.jsonwebtoken:jjwt-api:0.12.5" //강의노트 참고 토큰 관련 의존성
     runtimeOnly "io.jsonwebtoken:jjwt-impl:0.12.5"

--- a/schema.sql
+++ b/schema.sql
@@ -66,7 +66,8 @@ CREATE TABLE weathers
     temperature_min                    DOUBLE PRECISION NOT NULL,
     temperature_max                    DOUBLE PRECISION NOT NULL,
     wind_speed                         DOUBLE PRECISION NOT NULL,
-    wind_speed_as_word                 VARCHAR(20)      NOT NULL
+    wind_speed_as_word                 VARCHAR(20)      NOT NULL,
+    CONSTRAINT uq_weather_unique UNIQUE (location_x, location_y, forecasted_at, forecast_at)
 );
 
 CREATE TABLE clothes

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/batch/config/WeatherJobConfig.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/batch/config/WeatherJobConfig.java
@@ -11,18 +11,32 @@ import com.part4.team05.sb01otbooteam05.domain.weather.batch.processor.WeatherIt
 import com.part4.team05.sb01otbooteam05.domain.weather.batch.writer.WeatherItemWriter;
 import com.part4.team05.sb01otbooteam05.domain.weather.batch.writer.WeatherNotificationItemWriter;
 import com.part4.team05.sb01otbooteam05.domain.weather.entity.Weather;
+import com.part4.team05.sb01otbooteam05.domain.weather.service.WeatherService;
+import com.part4.team05.sb01otbooteam05.domain.weather.utils.BaseTimeUtils;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Future;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.integration.async.AsyncItemProcessor;
+import org.springframework.batch.integration.async.AsyncItemWriter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.transaction.PlatformTransactionManager;
 
+@Slf4j
 @Configuration
 @RequiredArgsConstructor
 public class WeatherJobConfig {
@@ -31,8 +45,6 @@ public class WeatherJobConfig {
   private final PlatformTransactionManager platformTransactionManager;
 
   private final WeatherItemReader weatherItemReader;
-  private final WeatherItemProcessor weatherItemProcessor;
-  private final WeatherItemWriter weatherItemWriter;
   private final WeatherNotificationItemWriter weatherNotificationItemWriter;
   private final CustomJobExecutionListener customJobExecutionListener;
   private final CustomStepExecutionListener customStepExecutionListener;
@@ -42,26 +54,35 @@ public class WeatherJobConfig {
 
   // 날씨 일괄 수집 작업 및 날씨 변동 알림을 정의하는 Spring Batch Job
   @Bean
-  public Job weatherJob() {
+  public Job weatherJob(
+      Step weatherStep,
+      Step weatherNotificationStep
+  ) {
     return new JobBuilder("weatherJob", jobRepository)
-        .start(weatherStep())
-        .next(weatherNotificationStep())
+        .start(weatherStep)
+        .next(weatherNotificationStep)
         .listener(customJobExecutionListener)
         .build();
   }
 
   // 날씨 일괄 수집 작업을 하는 Step
   @Bean
-  public Step weatherStep() {
+  public Step weatherStep(
+      AsyncItemProcessor<Pair<Integer, Integer>, List<Weather>> asyncWeatherItemProcessor,
+      AsyncItemWriter<List<Weather>> asyncWeatherItemWriter
+  ) {
     return new StepBuilder("weatherStep", jobRepository)
-        .<Pair<Integer, Integer>, List<Weather>>chunk(20, platformTransactionManager)
+        .<Pair<Integer, Integer>, Future<List<Weather>>>chunk(10, platformTransactionManager)
         .reader(weatherItemReader)
-        .processor(weatherItemProcessor)
-        .writer(weatherItemWriter)
+        .processor(asyncWeatherItemProcessor)
+        .writer(asyncWeatherItemWriter)
         .listener(customStepExecutionListener)
         .listener(customChunkListener)
         .listener(customItemReadListener)
         .listener(customItemProcessListener)
+        .faultTolerant()
+        .skip(Exception.class)
+        .skipLimit(1000) // 최대 1000건 예외 스킵
         .build();
   }
 
@@ -77,4 +98,50 @@ public class WeatherJobConfig {
         .listener(customItemReadListener)
         .build();
   }
+
+  // 비동기 TaskExecutor 세팅
+  @Bean
+  public TaskExecutor weatherTaskExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(8);
+    executor.setMaxPoolSize(16);
+    executor.setQueueCapacity(100);
+    executor.setThreadNamePrefix("weather-exec-");
+    executor.setWaitForTasksToCompleteOnShutdown(true);
+    executor.initialize();
+    return executor;
+  }
+
+  // 비동기 ItemProcessor 세팅
+  @Bean
+  @StepScope
+  public AsyncItemProcessor<Pair<Integer, Integer>, List<Weather>> asyncWeatherItemProcessor(
+      WeatherItemProcessor weatherItemProcessor,
+      WeatherService weatherService
+  ) {
+    LocalDate nowDate = LocalDate.now();
+    LocalTime time = BaseTimeUtils.standardTime(LocalTime.now()).withNano(0);
+    LocalDateTime forecastedAt = LocalDateTime.of(nowDate, time);
+
+    Set<Pair<Integer, Integer>> existLocationSet = weatherService.findExistingWeatherLocations(forecastedAt);
+
+    weatherItemProcessor.setExistLocationSet(existLocationSet);
+
+    AsyncItemProcessor<Pair<Integer, Integer>, List<Weather>> processor = new AsyncItemProcessor<>();
+    processor.setDelegate(weatherItemProcessor);
+    processor.setTaskExecutor(weatherTaskExecutor());
+    return processor;
+  }
+
+  // 비동기 ItemWriter 세팅
+  @Bean
+  @StepScope
+  public AsyncItemWriter<List<Weather>> asyncWeatherItemWriter(
+      WeatherItemWriter delegate
+  ) {
+    AsyncItemWriter<List<Weather>> writer = new AsyncItemWriter<>();
+    writer.setDelegate(delegate);
+    return writer;
+  }
+
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/batch/config/WeatherJobConfig.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/batch/config/WeatherJobConfig.java
@@ -119,10 +119,8 @@ public class WeatherJobConfig {
       WeatherItemProcessor weatherItemProcessor,
       WeatherService weatherService
   ) {
-    LocalDate nowDate = LocalDate.now();
-    LocalTime time = BaseTimeUtils.standardTime(LocalTime.now()).withNano(0);
-    LocalDateTime forecastedAt = LocalDateTime.of(nowDate, time);
 
+    LocalDateTime forecastedAt = BaseTimeUtils.getLatestBaseDateTimeAsDateTime();
     Set<Pair<Integer, Integer>> existLocationSet = weatherService.findExistingWeatherLocations(forecastedAt);
 
     weatherItemProcessor.setExistLocationSet(existLocationSet);

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/batch/processor/WeatherItemProcessor.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/batch/processor/WeatherItemProcessor.java
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Component;
 public class WeatherItemProcessor implements ItemProcessor<Pair<Integer, Integer>, List<Weather>> {
 
   private final WeatherService weatherService;
-  private Set<Pair<Integer, Integer>> existLocationSet;
+  private Set<Pair<Integer, Integer>> existLocationSet = Collections.emptySet();
 
   @Override
   public List<Weather> process(@NonNull Pair<Integer, Integer> location) {

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/batch/processor/WeatherItemProcessor.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/batch/processor/WeatherItemProcessor.java
@@ -2,12 +2,12 @@ package com.part4.team05.sb01otbooteam05.domain.weather.batch.processor;
 
 import com.part4.team05.sb01otbooteam05.domain.weather.entity.Weather;
 import com.part4.team05.sb01otbooteam05.domain.weather.service.WeatherService;
-import com.part4.team05.sb01otbooteam05.domain.weather.utils.BaseTimeUtils;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.batch.core.configuration.annotation.StepScope;
@@ -18,28 +18,33 @@ import org.springframework.stereotype.Component;
 @StepScope
 @RequiredArgsConstructor
 @Slf4j
+@Setter
 public class WeatherItemProcessor implements ItemProcessor<Pair<Integer, Integer>, List<Weather>> {
 
   private final WeatherService weatherService;
+  private Set<Pair<Integer, Integer>> existLocationSet;
 
   @Override
-  public List<Weather> process(Pair<Integer, Integer> location) {
-    int x = location.getLeft();
-    int y = location.getRight();
+  public List<Weather> process(@NonNull Pair<Integer, Integer> location) {
+    try {
+      log.info("🟢 process 진입");
 
-    LocalDate nowDate = LocalDate.now();
-    LocalTime time = BaseTimeUtils.standardTime(LocalTime.now()).withNano(0);
-    LocalDateTime forecastedAt = LocalDateTime.of(nowDate, time);
+      int x = location.getLeft();
+      int y = location.getRight();
 
-    if(weatherService.existWeather(x, y, forecastedAt)) {
-      log.info("이미 날씨 데이터 존재: x={}, y={}, forecastedAt = {}", x, y, forecastedAt);
-      return null;
+      Pair<Integer, Integer> key = Pair.of(x, y);
+      log.info("🟡 좌표 확인: x={}, y={}", x, y);
+      log.info("🟠 존재 여부: {}", existLocationSet.contains(key));
+
+      if (existLocationSet.contains(key)) {
+        return Collections.emptyList();
+      }
+
+      log.info("🔵 날씨 생성 시도: x={}, y={}", x, y);
+      return weatherService.generateWeather(x, y);
+    } catch (Exception e) {
+      log.error("❌ process() 내부에서 예외 발생", e);
+      return Collections.emptyList();
     }
-
-    log.info("날씨 데이터 생성 시작: x={}, y={}", x, y);
-    List<Weather> weatherList = weatherService.generateWeather(x, y);
-    log.info("날씨 데이터 생성 완료: x={}, y={}, 건수={}", x, y, weatherList.size());
-    return weatherList;
   }
-
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/batch/writer/WeatherItemWriter.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/batch/writer/WeatherItemWriter.java
@@ -35,7 +35,7 @@ public class WeatherItemWriter implements ItemWriter<List<Weather>> {
 
   @Override
   public void write(Chunk<? extends List<Weather>> items) {
-    log.info("Processor 실행 스레드: {}", Thread.currentThread().getName());
+    log.info("Writer 실행 스레드: {}", Thread.currentThread().getName());
 
     log.info("Writer received {} items", items.size());
     List<Object[]> objects = new ArrayList<>();

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/batch/writer/WeatherItemWriter.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/batch/writer/WeatherItemWriter.java
@@ -1,13 +1,16 @@
 package com.part4.team05.sb01otbooteam05.domain.weather.batch.writer;
 
 import com.part4.team05.sb01otbooteam05.domain.weather.entity.Weather;
-import com.part4.team05.sb01otbooteam05.domain.weather.repository.WeatherRepository;
+import com.part4.team05.sb01otbooteam05.domain.weather.mapper.WeatherJdbcMapper;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -16,20 +19,37 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class WeatherItemWriter implements ItemWriter<List<Weather>> {
 
-  private final WeatherRepository weatherRepository;
+  private static final String INSERT_SQL = """
+      INSERT INTO weathers (
+        id, location_x, location_y, forecasted_at, forecast_at,
+        sky_status, precipitation_type, precipitation_amount,
+        precipitation_probability, humidity_current, humidity_compared_to_day_before,
+        temperature_current, temperature_compared_to_day_before,
+        temperature_min, temperature_max,
+        wind_speed, wind_speed_as_word
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT (location_x, location_y, forecasted_at, forecast_at) DO NOTHING
+      """;
+
+  private final JdbcTemplate jdbcTemplate;
 
   @Override
   public void write(Chunk<? extends List<Weather>> items) {
+    log.info("Processor 실행 스레드: {}", Thread.currentThread().getName());
 
-    int total = 0;
-
+    log.info("Writer received {} items", items.size());
+    List<Object[]> objects = new ArrayList<>();
     for (List<Weather> weatherList : items) {
       if (weatherList != null && !weatherList.isEmpty()) {
-        weatherRepository.saveAll(weatherList);
-        total += weatherList.size();
+        for(Weather weather : weatherList) {
+          objects.add(WeatherJdbcMapper.toJdbcRow(weather));
+        }
       }
     }
-    log.info("날씨 데이터 저장 완료: 한 청크 내 총 {}건", total);
+    int[] result = jdbcTemplate.batchUpdate(INSERT_SQL, objects);
+
+    int totalInserted = Arrays.stream(result).sum();
+    log.info("날씨 데이터 저장 완료: 총 {}건", totalInserted);
   }
 
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/client/WeatherApiClient.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/client/WeatherApiClient.java
@@ -9,7 +9,12 @@ import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
@@ -22,6 +27,7 @@ import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
 //기상청 단기예보조회 OpenApi활용
+@Slf4j
 @Component
 public class WeatherApiClient {
 
@@ -30,6 +36,12 @@ public class WeatherApiClient {
 
   @Value("${weather.api.serviceKey}")
   private String serviceKey;
+
+  // 재시도 최대 횟수
+  private static final int MAX_RETRY_ON_NO_DATA = 3;
+
+  // 재시도 지연 시간
+  private static final long RETRY_DELAY_MS = 2000;
 
   //기상청 API 호출 -> 시간별 예보 정보를 WeatherResponse dto로 받음
   @Retryable(
@@ -53,20 +65,61 @@ public class WeatherApiClient {
         .queryParam("ny", y)
         .build(true);
 
-    ResponseEntity<WeatherResponse> response = new RestTemplate().getForEntity(uri.toUri(),
-        WeatherResponse.class);
+    // 기상청 api에 dataType=JSON 강제
+    HttpHeaders headers = new HttpHeaders();
+    headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+    HttpEntity<Void> entity = new HttpEntity<>(headers);
 
-    // 응답 없을 시 예외 발생
-    if (response.getBody() == null) {
-      throw new IllegalArgumentException("기상청 응답이 비어있습니다.");
+    // 기상청 api 응답 예외 처리 및 재시도
+    for (int attempt = 1; attempt <= MAX_RETRY_ON_NO_DATA; attempt++) {
+      try {
+        ResponseEntity<WeatherResponse> response = new RestTemplate().exchange(uri.toUri(), HttpMethod.GET, entity, WeatherResponse.class);
+        WeatherResponse weatherResponse = response.getBody();
+
+        if (weatherResponse == null || weatherResponse.getResponse() == null || weatherResponse.getResponse().getHeader() == null) {
+          throw new IllegalArgumentException("기상청 응답 구조가 유효하지 않습니다.");
+        }
+
+        String resultCode = weatherResponse.getResponse().getHeader().getResultCode();
+        String resultMsg = weatherResponse.getResponse().getHeader().getResultMsg();
+
+        if ("00".equals(resultCode)) {
+          if (weatherResponse.getResponse().getBody() == null ||
+              weatherResponse.getResponse().getBody().getItems() == null ||
+              weatherResponse.getResponse().getBody().getItems().getItem() == null) {
+            throw new IllegalArgumentException("기상청 응답이 유효하지 않습니다.");
+          }
+
+          log.info("기상청 응답 수신 완료: x={}, y={}, 항목 수={}",
+              x, y, weatherResponse.getResponse().getBody().getItems().getItem().size());
+
+          return parseForecastItems(weatherResponse);
+        }
+
+        if ("03".equals(resultCode)) {
+          log.warn("NO_DATA 응답 (x={}, y={}, 시도 {}/{}): {}", x, y, attempt, MAX_RETRY_ON_NO_DATA, resultMsg);
+          Thread.sleep(RETRY_DELAY_MS);
+        } else {
+          throw new IllegalArgumentException("기상청 응답 오류: " + resultMsg);
+        }
+
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException("재시도 대기 중 인터럽트 발생", e);
+      }
     }
 
-    return parseForecastItems(response.getBody());
+    throw new IllegalArgumentException("기상청 응답이 반복적으로 NO_DATA를 반환합니다.");
   }
 
   //기상청 API 응답 시간별로 파싱
   private ParsedForecastDto parseForecastItems(WeatherResponse response) {
     List<WeatherResponse.Item> items = response.getResponse().getBody().getItems().getItem();
+
+    if (items == null || items.isEmpty()) {
+      log.error("기상청 예보 항목이 비어 있음");
+      throw new IllegalArgumentException("예보 항목이 없습니다.");
+    }
 
     // 예보 등록 기준 시간
     WeatherResponse.Item firstItem = items.get(0);

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/entity/Weather.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/entity/Weather.java
@@ -4,7 +4,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
@@ -14,7 +13,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.UuidGenerator;
 
 @Getter
 @Entity
@@ -24,9 +22,9 @@ import org.hibernate.annotations.UuidGenerator;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Weather {
 
+  // jdbc 사용으로 인해 서비스에서 직접 생성
   @Id
-  @GeneratedValue
-  @UuidGenerator
+  @Column(nullable = false)
   private UUID id;
 
   @Column(name = "location_x", nullable = false)

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/mapper/WeatherCategoryMapper.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/mapper/WeatherCategoryMapper.java
@@ -4,7 +4,9 @@ import com.part4.team05.sb01otbooteam05.domain.weather.entity.PrecipitationType;
 import com.part4.team05.sb01otbooteam05.domain.weather.entity.SkyStatusType;
 import com.part4.team05.sb01otbooteam05.domain.weather.entity.WindSpeedAsWord;
 import com.part4.team05.sb01otbooteam05.domain.weather.exception.InvalidDataException;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class WeatherCategoryMapper {
   //변환 값은 기상청 단기예보 조회서비스 오픈 API 활용 가이드를 참고하였음
 
@@ -14,7 +16,10 @@ public class WeatherCategoryMapper {
       case "1" -> SkyStatusType.CLEAR;
       case "3" -> SkyStatusType.MOSTLY_CLOUDY;
       case "4" -> SkyStatusType.CLOUDY;
-      default -> throw new InvalidDataException("알수없는 코드값: " + skyCode);
+      default -> {
+        log.info("[SkyStatusType] 알 수 없는 코드값: {}", skyCode);
+        throw new InvalidDataException("알수없는 코드값: " + skyCode);
+      }
     };
   }
 
@@ -26,7 +31,10 @@ public class WeatherCategoryMapper {
       case "2" -> PrecipitationType.RAIN_SNOW;
       case "3" -> PrecipitationType.SNOW;
       case "4" -> PrecipitationType.SHOWER;
-      default -> throw new InvalidDataException("알수없는 코드값: " + ptyCode);
+      default -> {
+        log.info("[SkyStatusType] 알 수 없는 코드값: {}", ptyCode);
+        throw new InvalidDataException("알수없는 코드값: " + ptyCode);
+      }
     };
   }
 
@@ -52,6 +60,7 @@ public class WeatherCategoryMapper {
       return Double.parseDouble(pcpCode);
 
     } catch (NumberFormatException e) {
+      log.info("[SkyStatusType] 알 수 없는 코드값: {}", pcpCode);
       throw new InvalidDataException("알수없는 코드값: " + pcpCode);
     }
   }
@@ -61,6 +70,7 @@ public class WeatherCategoryMapper {
     try {
       return Double.parseDouble(popCode) / 100.0;
     } catch (NumberFormatException e) {
+      log.info("[SkyStatusType] 알 수 없는 코드값: {}", popCode);
       throw new InvalidDataException("알수없는 코드값: " + popCode);
     }
   }
@@ -78,6 +88,7 @@ public class WeatherCategoryMapper {
         return WindSpeedAsWord.STRONG;
       }
     } catch (NumberFormatException e) {
+      log.info("[SkyStatusType] 알 수 없는 코드값: {}", wsdCode);
       throw new InvalidDataException("알수없는 코드값: " + wsdCode);
     }
   }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/mapper/WeatherCategoryMapper.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/mapper/WeatherCategoryMapper.java
@@ -32,7 +32,7 @@ public class WeatherCategoryMapper {
       case "3" -> PrecipitationType.SNOW;
       case "4" -> PrecipitationType.SHOWER;
       default -> {
-        log.info("[SkyStatusType] 알 수 없는 코드값: {}", ptyCode);
+        log.info("[PrecipitationType] 알 수 없는 코드값: {}", ptyCode);
         throw new InvalidDataException("알수없는 코드값: " + ptyCode);
       }
     };
@@ -60,7 +60,7 @@ public class WeatherCategoryMapper {
       return Double.parseDouble(pcpCode);
 
     } catch (NumberFormatException e) {
-      log.info("[SkyStatusType] 알 수 없는 코드값: {}", pcpCode);
+      log.info("[PrecipitationAmount] 알 수 없는 코드값: {}", pcpCode);
       throw new InvalidDataException("알수없는 코드값: " + pcpCode);
     }
   }
@@ -70,7 +70,7 @@ public class WeatherCategoryMapper {
     try {
       return Double.parseDouble(popCode) / 100.0;
     } catch (NumberFormatException e) {
-      log.info("[SkyStatusType] 알 수 없는 코드값: {}", popCode);
+      log.info("[PrecipitationProbability] 알 수 없는 코드값: {}", popCode);
       throw new InvalidDataException("알수없는 코드값: " + popCode);
     }
   }
@@ -88,7 +88,7 @@ public class WeatherCategoryMapper {
         return WindSpeedAsWord.STRONG;
       }
     } catch (NumberFormatException e) {
-      log.info("[SkyStatusType] 알 수 없는 코드값: {}", wsdCode);
+      log.info("[WindSpeedAsWord] 알 수 없는 코드값: {}", wsdCode);
       throw new InvalidDataException("알수없는 코드값: " + wsdCode);
     }
   }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/mapper/WeatherJdbcMapper.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/mapper/WeatherJdbcMapper.java
@@ -1,0 +1,30 @@
+package com.part4.team05.sb01otbooteam05.domain.weather.mapper;
+
+import com.part4.team05.sb01otbooteam05.domain.weather.entity.Weather;
+import java.sql.Timestamp;
+
+public class WeatherJdbcMapper {
+
+  public static Object[] toJdbcRow(Weather weather){
+    return new Object[] {
+        weather.getId(),
+        weather.getLocationX(),
+        weather.getLocationY(),
+        Timestamp.valueOf(weather.getForecastedAt()),
+        Timestamp.valueOf(weather.getForecastAt()),
+        weather.getSkyStatusType().name(),
+        weather.getPrecipitationType().name(),
+        weather.getPrecipitationAmount(),
+        weather.getPrecipitationProbability(),
+        weather.getHumidityCurrent(),
+        weather.getHumidityComparedToDayBefore(),
+        weather.getTemperatureCurrent(),
+        weather.getTemperatureComparedToDayBefore(),
+        weather.getTemperatureMin(),
+        weather.getTemperatureMax(),
+        weather.getWindSpeed(),
+        weather.getWindSpeedAsWord().name()
+    };
+  }
+
+}

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/repository/WeatherRepository.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/repository/WeatherRepository.java
@@ -14,6 +14,13 @@ public interface WeatherRepository extends JpaRepository<Weather, UUID> {
   boolean existsByLocationXAndLocationYAndForecastedAt(Integer locationX, Integer locationY, LocalDateTime forecastedAt);
 
   @Query(value = """
+    SELECT DISTINCT location_x, location_y
+    FROM weathers
+    WHERE forecasted_at = :forecastedAt
+    """, nativeQuery = true)
+  List<Object[]> findLocationsByForecastedAt(LocalDateTime forecastedAt);
+
+  @Query(value = """
     SELECT DISTINCT ON (w.forecast_at) *
     FROM weathers w
     WHERE w.location_x = :x

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/scheduler/WeatherScheduler.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/scheduler/WeatherScheduler.java
@@ -20,7 +20,7 @@ public class WeatherScheduler {
   private final Job weatherJob;
   private final Job deleteOldWeatherJob;
 
-  @Scheduled(cron = "0 5 2,5,8,11,14,17,20,23 * * *")
+  @Scheduled(cron = "0 5,25 2,5,8,11,14,17,20,23 * * *")
   public void runWeatherJob() {
     try {
       JobParameters parameters = new JobParametersBuilder()

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/service/WeatherService.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/service/WeatherService.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,9 +48,16 @@ public class WeatherService {
 
   // 날씨 데이터 구성 시작
   public List<Weather> generateWeather(int x, int y) {
-    // x, y으로 기상청 api 호출 후 정제 전 날씨 데이터들 dto로 받아옴
-    ParsedForecastDto parsedForecastDto = weatherApiClient.fetchForecast(x, y);
-    return parsedForecastDtoToWeathers(parsedForecastDto, x, y);
+    log.info("📡 generateWeather 호출됨: x={}, y={}", x, y);
+    try{
+      // x, y으로 기상청 api 호출 후 정제 전 날씨 데이터들 dto로 받아옴
+      ParsedForecastDto parsedForecastDto = weatherApiClient.fetchForecast(x, y);
+      return parsedForecastDtoToWeathers(parsedForecastDto, x, y);
+    } catch (Exception e) {
+      log.error("generateWeather 실패: x={}, y={}, error={}", x, y, e.getMessage(), e);
+      throw e;
+    }
+
   }
 
   // 기상청 API 응답값 정제 후 엔티티 구성
@@ -76,17 +84,47 @@ public class WeatherService {
         .collect(Collectors.toList());
   }
 
-  // x, y, forecastedAt 값으로 날씨 데이터 유무 확인
-  public boolean existWeather(int x, int y, LocalDateTime forecastedAt) {
-    return weatherRepository.existsByLocationXAndLocationYAndForecastedAt(x, y, forecastedAt);
+  // 날씨 단건 조회 시 날씨 데이터 생성
+  @Transactional
+  public WeatherAPILocation getWeatherAPILocationAndGenerateWeather(double longitude,
+      double latitude) {
+    WeatherAPILocation weatherAPILocation = getWeatherAPILocation(longitude, latitude);
+    int x = weatherAPILocation.x();
+    int y = weatherAPILocation.y();
+    LocalDate nowDate = LocalDate.now();
+    LocalTime time = BaseTimeUtils.standardTime(LocalTime.now()).withNano(0);
+    LocalDateTime forecastedAt = LocalDateTime.of(nowDate, time);
+    boolean exists = existWeather(x, y, forecastedAt);
+
+    if (!exists) {
+      // 날씨 서비스 generateWeather 호출
+      List<Weather> weatherList = generateWeather(x, y);
+      // 날씨 엔티티 저장
+      if (weatherList != null && !weatherList.isEmpty()) {
+        weatherRepository.saveAll(weatherList);
+      }
+    } else {
+      log.info("날씨 데이터 존재: x={}, y={}", x, y);
+    }
+    return weatherAPILocation;
   }
 
-  @Transactional(readOnly = true)
-  public Weather getWeatherEntityByIdOrThrow(UUID weatherId) {
-    return weatherRepository.findById(weatherId)
-        .orElseThrow(() -> WeatherNotFoundException.withId(weatherId));
+  // 위도 경도 값으로 WeatherAPILocation 생성
+  public WeatherAPILocation getWeatherAPILocation(double longitude, double latitude) {
+    List<String> locationNames = kakaoApiService.getLocationNames(latitude, longitude);
+    LccGridConverter.XY gridXY = LccGridConverter.toGrid(latitude, longitude);
+
+    log.info("WeatherAPILocation 생성 : longitude = {}, latitude = {}, x = {}, y = {}", longitude, latitude, gridXY.x, gridXY.y);
+    return new WeatherAPILocation(
+        latitude,
+        longitude,
+        gridXY.x,
+        gridXY.y,
+        locationNames
+    );
   }
 
+  // 위치에 따른 날씨 리스트 조회
   @Transactional(readOnly = true)
   public List<WeatherDto> getWeathers(double longitude, double latitude) {
 
@@ -124,44 +162,26 @@ public class WeatherService {
         .collect(Collectors.toList());
   }
 
-  // 날씨 단건 조회 시 날씨 데이터 생성
-  @Transactional
-  public WeatherAPILocation getWeatherAPILocationAndGenerateWeather(double longitude,
-      double latitude) {
-    WeatherAPILocation weatherAPILocation = getWeatherAPILocation(longitude, latitude);
-    int x = weatherAPILocation.x();
-    int y = weatherAPILocation.y();
-    LocalDate nowDate = LocalDate.now();
-    LocalTime time = BaseTimeUtils.standardTime(LocalTime.now()).withNano(0);
-    LocalDateTime forecastedAt = LocalDateTime.of(nowDate, time);
-    boolean exists = existWeather(x, y, forecastedAt);
-
-    if (!exists) {
-      // 날씨 서비스 generateWeather 호출 시 트랜잭션 오류 방지 위해 직접 호출
-      ParsedForecastDto parsedForecastDto = weatherApiClient.fetchForecast(x, y);
-      List<Weather> weatherList = parsedForecastDtoToWeathers(parsedForecastDto, x, y);
-      if (weatherList != null && !weatherList.isEmpty()) {
-        weatherRepository.saveAll(weatherList);
-      }
-    } else {
-      log.info("날씨 데이터 존재: x={}, y={}", x, y);
-    }
-    return weatherAPILocation;
+  // 날씨 id 조회
+  @Transactional(readOnly = true)
+  public Weather getWeatherEntityByIdOrThrow(UUID weatherId) {
+    return weatherRepository.findById(weatherId)
+        .orElseThrow(() -> WeatherNotFoundException.withId(weatherId));
   }
 
-  // 위도 경도 값으로 WeatherAPILocation 생성
-  public WeatherAPILocation getWeatherAPILocation(double longitude, double latitude) {
-    List<String> locationNames = kakaoApiService.getLocationNames(latitude, longitude);
-    LccGridConverter.XY gridXY = LccGridConverter.toGrid(latitude, longitude);
+  // x, y, forecastedAt 값으로 날씨 데이터 유무 확인
+  @Transactional(readOnly = true)
+  public boolean existWeather(int x, int y, LocalDateTime forecastedAt) {
+    return weatherRepository.existsByLocationXAndLocationYAndForecastedAt(x, y, forecastedAt);
+  }
 
-    log.info("WeatherAPILocation 생성 : longitude = {}, latitude = {}, x = {}, y = {}", longitude, latitude, gridXY.x, gridXY.y);
-    return new WeatherAPILocation(
-        latitude,
-        longitude,
-        gridXY.x,
-        gridXY.y,
-        locationNames
-    );
+  // forecastedAt 값에 해당해서 존재하는 날씨 위치(x,y) Set 으로 조회
+  @Transactional(readOnly = true)
+  public Set<Pair<Integer, Integer>> findExistingWeatherLocations(LocalDateTime forecastedAt) {
+    List<Object[]> results = weatherRepository.findLocationsByForecastedAt(forecastedAt);
+    return results.stream()
+        .map(arr -> Pair.of((Integer) arr[0], (Integer) arr[1]))
+        .collect(Collectors.toSet());
   }
 
   // 전날 데이터 확인
@@ -284,6 +304,7 @@ public class WeatherService {
       Double minTemp, Double maxTemp
   ) {
     return Weather.builder()
+        .id(UUID.randomUUID())
         .locationX(x)
         .locationY(y)
         .forecastedAt(forecastedAt)

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/utils/BaseTimeUtils.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/weather/utils/BaseTimeUtils.java
@@ -28,17 +28,23 @@ public class BaseTimeUtils {
 
     LocalTime latestBaseTime = standardTime(nowTime);
 
-    if (latestBaseTime != null) {
-      return Pair.of(nowDate, formatTime(latestBaseTime));
+    if (latestBaseTime.equals(LocalTime.of(23, 0)) && nowTime.isBefore(LocalTime.of(2, 0))) {
+      return Pair.of(nowDate.minusDays(1), formatTime(latestBaseTime));
     }
-    return Pair.of(nowDate.minusDays(1), "2300");
+
+    return Pair.of(nowDate, formatTime(latestBaseTime));
+  }
+
+  public static LocalDateTime getLatestBaseDateTimeAsDateTime() {
+    Pair<LocalDate, String> pair = getLatestBaseDateTime();
+    return toDateTime(pair.getLeft().format(DateTimeFormatter.ofPattern("yyyyMMdd")), pair.getRight());
   }
 
   public static LocalTime standardTime(LocalTime localTime) {
     return STANDARD_TIMES.stream()
         .filter(time -> !localTime.isBefore(time))
         .reduce((first, second) -> second)
-        .orElse(null);
+        .orElse(LocalTime.of(23, 0));
   }
 
   private static String formatTime(LocalTime time) {

--- a/src/test/java/com/part4/team05/sb01otbooteam05/domain/weather/service/WeatherServiceTest.java
+++ b/src/test/java/com/part4/team05/sb01otbooteam05/domain/weather/service/WeatherServiceTest.java
@@ -1,0 +1,188 @@
+package com.part4.team05.sb01otbooteam05.domain.weather.service;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.part4.team05.sb01otbooteam05.domain.user.service.KakaoApiService;
+import com.part4.team05.sb01otbooteam05.domain.weather.client.WeatherApiClient;
+import com.part4.team05.sb01otbooteam05.domain.weather.dto.ParsedForecastDto;
+import com.part4.team05.sb01otbooteam05.domain.weather.dto.WeatherAPILocation;
+import com.part4.team05.sb01otbooteam05.domain.weather.dto.WeatherDto;
+import com.part4.team05.sb01otbooteam05.domain.weather.entity.Weather;
+import com.part4.team05.sb01otbooteam05.domain.weather.repository.WeatherRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class WeatherServiceTest {
+
+  @Mock
+  private WeatherApiClient weatherApiClient;
+
+  @Mock
+  private WeatherRepository weatherRepository;
+
+  @Mock
+  private KakaoApiService kakaoApiService;
+
+  @InjectMocks
+  private WeatherService weatherService;
+
+  private final int x = 60;
+  private final int y = 127;
+  private final LocalDateTime forecastedAt = LocalDateTime.of(2025, 7, 27, 14, 0);
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+
+  @Test
+  void generateWeather() {
+    int x = 60;
+    int y = 127;
+    LocalDateTime forecastedAt = LocalDateTime.now();
+    Map<LocalDateTime, Map<String, String>> forecastMap = new HashMap<>();
+    Map<String, String> data = Map.of(
+        "TMP", "25",
+        "REH", "60",
+        "SKY", "1",
+        "PTY", "0",
+        "PCP", "강수없음",
+        "POP", "10",
+        "WSD", "1.5"
+    );
+    forecastMap.put(forecastedAt.plusHours(1), data);
+
+    ParsedForecastDto parsedForecastDto = new ParsedForecastDto(forecastedAt, forecastMap);
+    when(weatherApiClient.fetchForecast(x, y)).thenReturn(parsedForecastDto);
+
+    List<Weather> result = weatherService.generateWeather(x, y);
+
+    assertThat(result).isNotEmpty();
+    assertThat(result.get(0).getLocationX()).isEqualTo(x);
+    assertThat(result.get(0).getLocationY()).isEqualTo(y);
+    assertThat(result.get(0).getTemperatureCurrent()).isEqualTo(25);
+    assertThat(result.get(0).getHumidityCurrent()).isEqualTo(60);
+  }
+
+  @Test
+  void existWeather() {
+    when(weatherRepository.existsByLocationXAndLocationYAndForecastedAt(x, y, forecastedAt))
+        .thenReturn(true);
+
+    boolean exists = weatherService.existWeather(x, y, forecastedAt);
+
+    assertThat(exists).isTrue();
+  }
+
+
+  @Test
+  void getWeatherEntityByIdOrThrow() {
+    UUID id = UUID.randomUUID();
+    Weather weather = Weather.builder().id(id).build();
+    when(weatherRepository.findById(id)).thenReturn(Optional.of(weather));
+
+    Weather result = weatherService.getWeatherEntityByIdOrThrow(id);
+
+    assertThat(result.getId()).isEqualTo(id);
+  }
+
+  @Test
+  void findExistingWeatherLocations() {
+    LocalDateTime forecastedAt = LocalDateTime.now();
+    List<Object[]> mockResult = List.of(new Object[]{60, 127}, new Object[]{61, 128});
+    when(weatherRepository.findLocationsByForecastedAt(forecastedAt)).thenReturn(mockResult);
+
+    Set<Pair<Integer, Integer>> locations = weatherService.findExistingWeatherLocations(forecastedAt);
+
+    assertThat(locations).containsExactlyInAnyOrder(
+        Pair.of(60, 127),
+        Pair.of(61, 128)
+    );
+  }
+
+  @Test
+  void getWeatherAPILocationTest() {
+    // given
+    double latitude = 37.5665;
+    double longitude = 126.9780;
+    when(kakaoApiService.getLocationNames(anyDouble(), anyDouble()))
+        .thenReturn(List.of("서울특별시", "중구"));
+
+    // when
+    WeatherAPILocation result = weatherService.getWeatherAPILocation(longitude, latitude);
+
+    // then
+    assertThat(result.latitude()).isEqualTo(latitude);
+    assertThat(result.longitude()).isEqualTo(longitude);
+    assertThat(result.x()).isNotNull();
+    assertThat(result.y()).isNotNull();
+    assertThat(result.locationNames()).contains("서울특별시");
+  }
+
+
+  @Test
+  void getWeathersTest() {
+    // given
+    double lat = 37.5665;
+    double lon = 126.9780;
+    int x = 59;
+    int y = 126;
+
+    LocalDateTime now = LocalDateTime.now();
+    LocalTime requestedTime = now.toLocalTime()
+        .plusHours(1)
+        .truncatedTo(java.time.temporal.ChronoUnit.HOURS)
+        .withSecond(0).withNano(0);
+
+    List<LocalDateTime> forecastAtList = new ArrayList<>();
+    for (int i = 0; i <= 4; i++) {
+      LocalDate targetDate = now.toLocalDate().plusDays(i);
+      LocalTime targetTime = i < 3 ? requestedTime : LocalTime.MIDNIGHT;
+      forecastAtList.add(LocalDateTime.of(targetDate, targetTime).withSecond(0).withNano(0));
+    }
+
+    Weather weather = Weather.builder()
+        .id(UUID.randomUUID())
+        .locationX(x)
+        .locationY(y)
+        .forecastAt(forecastAtList.get(0))
+        .forecastedAt(now)
+        .temperatureCurrent(25.0)
+        .humidityCurrent(60.0)
+        .build();
+
+    when(kakaoApiService.getLocationNames(lat, lon)).thenReturn(List.of("서울"));
+    when(weatherRepository.findLatestByLocationAndForecastAtIn(eq(x), eq(y), anyList()))
+        .thenReturn(List.of(weather));
+
+    // when
+    List<WeatherDto> result = weatherService.getWeathers(lon, lat);
+
+    // then
+    assertThat(result).isNotEmpty();
+    assertThat(result.get(0).temperature().current()).isEqualTo(25.0);
+    assertThat(result.get(0).location().locationNames()).contains("서울");
+  }
+
+
+}


### PR DESCRIPTION
## 🛰️ PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  버그 수정
- [x]  의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🪐 변경 사항
날씨 테이블에 유니크 조건 추가.
날씨 저장 job의 itemWriter를 jdbcTemplate.batchUpdate로 리펙토링.
날씨 저장 배치 AsyncItemProcessor, AsyncItemWriter 도입하여 비동기 처리로 리펙토링.
BaseTimeUtils 버그 수정.
날씨 저장 스케줄링 해당하는 시각의 5분, 25분 총 2번 실행으로 변경 
-> 기상청 API에서 XML 로만 반환하는 일이 있어서 방어적으로 2번 실행.
WeatherServiceTest 단위테스트 작성.

## 💬 공유사항 to 리뷰어



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 날씨 데이터 배치 작업에 비동기 처리 및 장애 허용 기능이 추가되어 동시성과 안정성이 향상되었습니다.
  * 날씨 데이터 중복 저장 방지를 위한 고유 제약조건이 도입되었습니다.
  * 위경도 기반 위치 변환 및 기존 데이터 좌표 조회 기능이 추가되었습니다.

* **버그 수정**
  * 새벽 시간대의 기준시 계산이 실제 시간에 맞게 개선되었습니다.

* **성능 개선**
  * JDBC를 활용한 대량 데이터 삽입으로 저장 성능이 향상되었습니다.

* **개선 및 변경**
  * 날씨 API 호출 시 "NO_DATA" 응답에 대해 최대 3회 재시도 및 상세 로그가 추가되었습니다.
  * UUID 생성 방식이 변경되어 서비스 레이어에서 직접 할당합니다.
  * 스케줄러 실행 주기가 시간당 2회(5분, 25분)로 증가하였습니다.
  * 날씨 데이터 처리 로직에 상세 로그와 예외 처리 강화가 이루어졌습니다.
  * 위치 코드 변환 시 잘못된 입력에 대한 로깅이 추가되어 문제 추적이 용이해졌습니다.
  * 기준 시간 계산 및 변환 유틸리티가 개선되었습니다.

* **문서화 및 테스트**
  * WeatherService에 대한 단위 테스트가 추가되어 신뢰성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->