### PR TITLE
[#130] 알림, 팔로우, DM 테스트 코드 개선

### DIFF
--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/notification/service/impl/NotificationServiceImpl.java
@@ -156,6 +156,4 @@ public class NotificationServiceImpl implements NotificationService {
             }
         }
     }
-
-
 }

--- a/src/test/java/com/part4/team05/sb01otbooteam05/domain/follow/FollowServiceImplTest.java
+++ b/src/test/java/com/part4/team05/sb01otbooteam05/domain/follow/FollowServiceImplTest.java
@@ -105,14 +105,6 @@ class FollowServiceImplTest {
                     );
         }
 
-        @Test @DisplayName("실패: 팔로워가 없음")
-        void followerNotFound() {
-            given(userRepository.existsById(followerId)).willReturn(false);
-            assertThatThrownBy(() -> service.createFollow(new FollowCreateRequest(followeeId, followerId)))
-                    .isInstanceOf(FollowException.class)
-                    .extracting("errorCode").isEqualTo(ErrorCode.USER_NOT_FOUND);
-        }
-
         @Test @DisplayName("실패: 자기 자신 팔로우 금지")
         void selfFollowNotAllowed() {
             given(userRepository.existsById(followerId)).willReturn(true);
@@ -276,6 +268,17 @@ class FollowServiceImplTest {
                     .isInstanceOf(FollowException.class)
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.USER_NOT_FOUND);
+        }
+
+        @Test @DisplayName("실패: 팔로이(followee)가 없음")
+        void followeeNotFound() {
+            given(userRepository.existsById(followerId)).willReturn(true);
+            given(userRepository.existsById(followeeId)).willReturn(false);
+            assertThatThrownBy(() ->
+                    service.createFollow(new FollowCreateRequest(followeeId, followerId))
+            )
+                    .isInstanceOf(FollowException.class)
+                    .extracting("errorCode").isEqualTo(ErrorCode.USER_NOT_FOUND);
         }
 
         @Test @DisplayName("성공: 알림 전송 중 예외 발생해도 정상 반환")

--- a/src/test/java/com/part4/team05/sb01otbooteam05/domain/notification/NotificationServiceImplTest.java
+++ b/src/test/java/com/part4/team05/sb01otbooteam05/domain/notification/NotificationServiceImplTest.java
@@ -12,6 +12,7 @@ import com.part4.team05.sb01otbooteam05.domain.user.entity.User;
 import com.part4.team05.sb01otbooteam05.exception.ErrorCode;
 import com.part4.team05.sb01otbooteam05.exception.OtbooException;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -187,24 +188,42 @@ class NotificationServiceImplTest {
     }
 
     @Test
-    void testRemoveEmitter_partialAndLast_viaReflection() throws Exception {
+    @DisplayName("SseEmitter가 complete된 후 send하면 예외 발생하고 제거되는지 확인")
+    void testEmitterRemovalWhenSendAfterCompletion() throws Exception {
+        // given
         UUID userId = UUID.randomUUID();
-        SseEmitter e1 = service.connect(userId, null);
-        SseEmitter e2 = service.connect(userId, null);
 
-        Field f = NotificationServiceImpl.class.getDeclaredField("emittersMap");
-        f.setAccessible(true);
+        // emitter1: 이미 완료된 emitter (IOException 발생 시 제거 대상)
+        SseEmitter emitter1 = mock(SseEmitter.class);
+        doThrow(new IOException("ResponseBodyEmitter has already completed"))
+                .when(emitter1).send(any(SseEmitter.SseEventBuilder.class));
+        doNothing().when(emitter1).completeWithError(any());
+
+        // emitter2: 정상 동작
+        SseEmitter emitter2 = mock(SseEmitter.class);
+
+        // emittersMap 직접 삽입
+        Field field = NotificationServiceImpl.class.getDeclaredField("emittersMap");
+        field.setAccessible(true);
         @SuppressWarnings("unchecked")
-        Map<UUID, List<SseEmitter>> map = (Map<UUID, List<SseEmitter>>) f.get(service);
-        assertThat(map.get(userId)).hasSize(2);
+        Map<UUID, List<SseEmitter>> emittersMap = (Map<UUID, List<SseEmitter>>) field.get(service);
+        emittersMap.put(userId, new CopyOnWriteArrayList<>(List.of(emitter1, emitter2)));
 
-        Method rm = NotificationServiceImpl.class.getDeclaredMethod("removeEmitter", UUID.class, SseEmitter.class);
-        rm.setAccessible(true);
-        rm.invoke(service, userId, e1);
-        assertThat(map.get(userId)).containsExactly(e2);
-        rm.invoke(service, userId, e2);
-        assertThat(map).doesNotContainKey(userId);
+        NotificationDto dto = new NotificationDto(
+                UUID.randomUUID(), LocalDateTime.now(), userId,
+                "제목", "내용", NotificationLevel.INFO
+        );
+
+        // when
+        service.sendNotification(dto);
+
+        // then
+        List<SseEmitter> remaining = emittersMap.get(userId);
+        assertThat(remaining).containsExactly(emitter2); // emitter1 제거 확인
+        verify(emitter1).completeWithError(any(IOException.class)); // 예외 처리 확인
+        verify(emitter2).send(any(SseEmitter.SseEventBuilder.class)); // 정상 작동 확인
     }
+
 
     @Test
     void testCreateAndSendNotification_invokesSendNotification() {


### PR DESCRIPTION
## 🛰️ PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ]  기능 추가
- [ ]  기능 삭제
- [x]  버그 수정
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🪐 변경 사항
- 알림(NotificationServiceImplTest) 테스트 로직 개선
  - SseEmitter 예외 상황 테스트 추가
  - emitter 제거 테스트 리팩토링

- 팔로우(FollowServiceImplTest), DM 테스트 코드 개선

## 💬 공유사항 to 리뷰어
- 주요 비즈니스 로직은 수정 없이 테스트 코드만 개선하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 팔로우 생성 시 팔로이(followee)가 존재하지 않을 때 예외가 발생하는 테스트가 추가되었습니다.
  * 팔로워(follower)가 존재하지 않을 때의 실패 테스트가 새로운 테스트 클래스 내로 이동되었습니다.
  * 알림 SSEEmitter가 완료된 후 send 시 예외 발생 및 제거 여부를 확인하는 테스트가 개선되고, 테스트명이 명확하게 변경되었습니다.

* **스타일**
  * 코드 내 불필요한 공백이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->