### PR TITLE
[#136] 의상 정리 및 배포 관련 얌 파일

### DIFF
--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/security/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/auth/security/handler/OAuth2AuthenticationSuccessHandler.java
@@ -37,8 +37,9 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
       SignInResponse authResponse = authService.signInOAuthUser(userDetails);
       log.info("토큰 발급 완료");
 
-      addRefreshTokenCookie(response, authResponse.getRefreshToken());
-      addAccessTokenCookie(response, authResponse.getAccessToken());
+      boolean isSecure = isSecureRequest(request);
+      addRefreshTokenCookie(response, authResponse.getRefreshToken(), isSecure);
+      addAccessTokenCookie(response, authResponse.getAccessToken(), isSecure);
 
       String targetUrl = appOAuth2Properties.getRedirect().getSuccessUrl();
 
@@ -52,23 +53,32 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     }
   }
 
-  private void addRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+  private void addRefreshTokenCookie(HttpServletResponse response, String refreshToken, boolean isSecure) {
     Cookie cookie = new Cookie("refresh_token", refreshToken);
     cookie.setHttpOnly(true);
-    cookie.setSecure(false);
+    cookie.setSecure(isSecure);
     cookie.setPath("/");
     cookie.setMaxAge(7 * 24 * 60 * 60); // 7일
     response.addCookie(cookie);
+
+    log.info("RefreshToken 쿠키 설정 완료 (Secure: {})", isSecure);
   }
 
-  private void addAccessTokenCookie(HttpServletResponse response, String accessToken) {
+  private void addAccessTokenCookie(HttpServletResponse response, String accessToken, boolean isSecure) {
     Cookie cookie = new Cookie("access_token", accessToken);
     cookie.setHttpOnly(false);
-    cookie.setSecure(false);   // HTTP 환경
+    cookie.setSecure(isSecure);
     cookie.setPath("/");
     cookie.setMaxAge(30 * 60); // 30분
     response.addCookie(cookie);
 
-    log.info("AccessToken 쿠키 설정 완료");
+    log.info("AccessToken 쿠키 설정 완료 (Secure: {})", isSecure);
+  }
+
+  private boolean isSecureRequest(HttpServletRequest request) {
+    // HTTPS 직접 연결 또는 로드밸런서를 통한 HTTPS 요청 감지
+    return request.isSecure() ||
+        "https".equalsIgnoreCase(request.getHeader("X-Forwarded-Proto")) ||
+        "https".equalsIgnoreCase(request.getHeader("X-Forwarded-Scheme"));
   }
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/clothes/controller/ClothesController.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/clothes/controller/ClothesController.java
@@ -65,3 +65,4 @@ public class ClothesController implements ClothesControllerDoc{
     return ResponseEntity.ok().body(clothesService.update(clothesId,request,image));
   }
 }
+

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/clothes/controller/ClothesController.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/clothes/controller/ClothesController.java
@@ -35,11 +35,16 @@ public class ClothesController implements ClothesControllerDoc{
   public ResponseEntity<ClothesCursorResponse> getClothes(
       @RequestParam UUID ownerId,
       @RequestParam(required = false) UUID cursor,
-      @RequestParam(defaultValue = "10") int size) {
+      @RequestParam(required = false) String idAfter,
+      @RequestParam(defaultValue = "10") int limit,
+      @RequestParam(required = false) String typeEqual) {
 
-    ClothesCursorResponse response = clothesService.get(ownerId, cursor, size);
+    UUID actualCursor = cursor != null ? cursor : (idAfter != null ? UUID.fromString(idAfter) : null);
+
+    ClothesCursorResponse response = clothesService.get(ownerId, actualCursor, limit, typeEqual);
     return ResponseEntity.ok(response);
   }
+
 
   @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<ClothesDto> saveClothes(@RequestPart("request") ClothesCreateRequest request,

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/clothes/controller/ClothesControllerDoc.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/clothes/controller/ClothesControllerDoc.java
@@ -1,9 +1,9 @@
 package com.part4.team05.sb01otbooteam05.domain.clothes.controller;
 
-import com.part4.team05.sb01otbooteam05.domain.clothes.dto.ClothesCursorResponse;
-import com.part4.team05.sb01otbooteam05.domain.clothes.dto.ClothesUpdateRequest;
 import com.part4.team05.sb01otbooteam05.domain.clothes.dto.ClothesCreateRequest;
+import com.part4.team05.sb01otbooteam05.domain.clothes.dto.ClothesCursorResponse;
 import com.part4.team05.sb01otbooteam05.domain.clothes.dto.ClothesDto;
+import com.part4.team05.sb01otbooteam05.domain.clothes.dto.ClothesUpdateRequest;
 import com.part4.team05.sb01otbooteam05.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -12,13 +12,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.UUID;
 
 @Tag(name = "의상 관리", description = "의상 관련 API")
 public interface ClothesControllerDoc {
@@ -47,7 +46,9 @@ public interface ClothesControllerDoc {
   ResponseEntity<ClothesCursorResponse> getClothes(
       @Parameter(description = "ownerId", required = true) @RequestParam UUID ownerId,
       @Parameter(description = "cursor") @RequestParam(required = false) UUID cursor,
-      @Parameter(description = "limit", example = "10") @RequestParam(defaultValue = "10") int size
+      @Parameter(description = "idAfter") @RequestParam(required = false) String idAfter,
+      @Parameter(description = "limit", example = "10") @RequestParam(defaultValue = "10") int limit, // size → limit
+      @Parameter(description = "clothes type filter") @RequestParam(required = false) String typeEqual
   );
 
   @Operation(

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/clothes/controller/ClothesControllerDoc.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/clothes/controller/ClothesControllerDoc.java
@@ -136,3 +136,5 @@ public interface ClothesControllerDoc {
       @RequestPart(required = false, value = "image") MultipartFile image
   );
 }
+
+

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/clothes/dto/ClothesCursorResponse.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/clothes/dto/ClothesCursorResponse.java
@@ -15,3 +15,4 @@ public class ClothesCursorResponse {
   String sortBy;
   String sortDirection;
 }
+

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/clothes/dto/ClothesCursorResponse.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/clothes/dto/ClothesCursorResponse.java
@@ -7,12 +7,11 @@ import lombok.Setter;
 @Getter
 @Setter
 public class ClothesCursorResponse {
-  List<ClothesDto> clothesDtos;
+  List<ClothesDto> data; // clothesDtos -> data로 변경
   String nextCursor;
   String nextIdAfter;
   boolean hasNext;
-  Integer nextCount;
+  Integer totalCount;
   String sortBy;
   String sortDirection;
-
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/clothes/mapper/ClothesMapper.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/clothes/mapper/ClothesMapper.java
@@ -1,19 +1,34 @@
 package com.part4.team05.sb01otbooteam05.domain.clothes.mapper;
 
 
+import com.part4.team05.sb01otbooteam05.domain.attribute.dto.AttributeDto;
+import com.part4.team05.sb01otbooteam05.domain.attribute.entity.AttributeValue;
 import com.part4.team05.sb01otbooteam05.domain.clothes.dto.ClothesDto;
 import com.part4.team05.sb01otbooteam05.domain.clothes.entity.Clothes;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface ClothesMapper {
 
+  @Mapping(target = "attributes", expression = "java(mapAttributeValues(clothes.getAttributeValues()))")
+  @Mapping(target = "type", expression = "java(clothes.getType() != null ? clothes.getType().name() : null)")
   ClothesDto toDto(Clothes clothes);
 
+  @Mapping(target = "attributeValues", ignore = true)
   Clothes toEntity(ClothesDto clothesDto);
 
   List<ClothesDto> toDtoList(List<Clothes> list);
 
+  default List<AttributeDto> mapAttributeValues(List<AttributeValue> attributeValues) {
+    if (attributeValues == null) {
+      return java.util.Collections.emptyList();
+    }
+
+    return attributeValues.stream()
+        .map(AttributeDto::new)
+        .collect(Collectors.toList());
+  }
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/clothes/mapper/ClothesMapper.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/clothes/mapper/ClothesMapper.java
@@ -32,3 +32,5 @@ public interface ClothesMapper {
         .collect(Collectors.toList());
   }
 }
+
+

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/clothes/repository/ClothesRepository.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/clothes/repository/ClothesRepository.java
@@ -1,14 +1,13 @@
 package com.part4.team05.sb01otbooteam05.domain.clothes.repository;
 
-import com.part4.team05.sb01otbooteam05.domain.clothes.dto.ClothesDto;
 import com.part4.team05.sb01otbooteam05.domain.clothes.entity.Clothes;
 import com.part4.team05.sb01otbooteam05.domain.clothes.entity.ClothesType;
-
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -20,7 +19,12 @@ public interface ClothesRepository extends JpaRepository<Clothes, UUID> {
     SELECT c FROM Clothes c
     WHERE c.ownerId = :ownerId
       AND (:cursor IS NULL OR c.id < :cursor)
+      AND (:type IS NULL OR c.type = :type)
     ORDER BY c.id DESC
 """)
-  List<Clothes> findByOwnerIdPageNation(UUID ownerId, UUID cursor , Pageable pageable);
+  List<Clothes> findByOwnerIdPageNation(
+      @Param("ownerId") UUID ownerId,
+      @Param("cursor") UUID cursor,
+      @Param("type") ClothesType type,
+      Pageable pageable);
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/clothes/repository/ClothesRepository.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/clothes/repository/ClothesRepository.java
@@ -28,3 +28,4 @@ public interface ClothesRepository extends JpaRepository<Clothes, UUID> {
       @Param("type") ClothesType type,
       Pageable pageable);
 }
+

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/clothes/service/ClothesS3Service.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/clothes/service/ClothesS3Service.java
@@ -22,10 +22,14 @@ public class ClothesS3Service {
 
   private final S3Client s3Client;
 
-  @Value("${clothes.bucket}")
+  @Value("${spring.cloud.aws.s3.bucket}")
   private String bucketName;
 
+  private static final String CLOTHES_FOLDER = "clothes/";
+
   public String upload(UUID clothesId, MultipartFile file) {
+    log.info("S3 업로드 시도: bucket={}, clothesId={}", bucketName, clothesId);
+
     try {
       String originalFilename = file.getOriginalFilename();
       String extension = "";
@@ -33,7 +37,10 @@ public class ClothesS3Service {
         extension = originalFilename.substring(originalFilename.lastIndexOf("."));
       }
 
-      String fileName = clothesId.toString() + "_" + System.currentTimeMillis() + extension;
+      // clothes/ 폴더 안에 저장
+      String fileName = CLOTHES_FOLDER + clothesId.toString() + "_" + System.currentTimeMillis() + extension;
+
+      log.info("S3 파일명: {}", fileName);
 
       PutObjectRequest putObjectRequest = PutObjectRequest.builder()
           .bucket(bucketName)
@@ -50,9 +57,13 @@ public class ClothesS3Service {
           .key(fileName)
           .build();
 
-      return s3Client.utilities().getUrl(getUrlRequest).toExternalForm();
+      String url = s3Client.utilities().getUrl(getUrlRequest).toExternalForm();
+      log.info("S3 업로드 성공: {}", url);
+
+      return url;
 
     } catch (IOException e) {
+      log.error("S3 업로드 실패: bucket={}, clothesId={}, error={}", bucketName, clothesId, e.getMessage());
       throw new RuntimeException("이미지 업로드에 실패했습니다", e);
     }
   }
@@ -60,6 +71,7 @@ public class ClothesS3Service {
   public void delete(String fileUrl) {
     try {
       String fileName = extractFileNameFromUrl(fileUrl);
+      log.info("S3 파일 삭제 시도: bucket={}, fileName={}", bucketName, fileName);
 
       if (fileName != null) {
         try {
@@ -76,16 +88,16 @@ public class ClothesS3Service {
               .build();
 
           s3Client.deleteObject(deleteObjectRequest);
+          log.info("S3 파일 삭제 성공: {}", fileName);
 
         } catch (NoSuchKeyException e) {
           log.warn("삭제하려는 파일이 S3에 존재하지 않음: fileName={}", fileName);
         }
       }
     } catch (Exception e) {
-      log.error("S3 파일 삭제 실패: fileUrl={}", fileUrl, e);
+      log.error("S3 파일 삭제 실패: fileUrl={}, error={}", fileUrl, e.getMessage());
     }
   }
-
 
   private String extractFileNameFromUrl(String fileUrl) {
     if (fileUrl == null || !fileUrl.contains(bucketName)) {
@@ -93,9 +105,15 @@ public class ClothesS3Service {
     }
 
     try {
+      String bucketPath = bucketName + "/";
+      int bucketIndex = fileUrl.indexOf(bucketPath);
+      if (bucketIndex != -1) {
+        return fileUrl.substring(bucketIndex + bucketPath.length());
+      }
+
       String[] parts = fileUrl.split("/");
-      if (parts.length >= 1) {
-        return parts[parts.length - 1];
+      if (parts.length >= 2) {
+        return parts[parts.length - 2] + "/" + parts[parts.length - 1];
       }
     } catch (Exception e) {
       log.warn("URL에서 파일명 추출 실패: {}", fileUrl, e);

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/clothes/service/ClothesS3Service.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/clothes/service/ClothesS3Service.java
@@ -122,3 +122,4 @@ public class ClothesS3Service {
     return null;
   }
 }
+

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/clothes/service/ClothesService.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/clothes/service/ClothesService.java
@@ -1,21 +1,5 @@
 package com.part4.team05.sb01otbooteam05.domain.clothes.service;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Optional;
-import java.util.UUID;
-
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import com.part4.team05.sb01otbooteam05.domain.attribute.entity.AttributeValue;
 import com.part4.team05.sb01otbooteam05.domain.attribute.service.AttributeService;
@@ -28,9 +12,19 @@ import com.part4.team05.sb01otbooteam05.domain.clothes.entity.ClothesType;
 import com.part4.team05.sb01otbooteam05.domain.clothes.exception.ClothesNotFoundException;
 import com.part4.team05.sb01otbooteam05.domain.clothes.mapper.ClothesMapper;
 import com.part4.team05.sb01otbooteam05.domain.clothes.repository.ClothesRepository;
-
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ClothesService {
@@ -40,19 +34,27 @@ public class ClothesService {
   private final ClothesS3Service clothesS3Service;
 
 
-  public ClothesCursorResponse get(UUID ownerId, UUID cursor, int size) {
-    Pageable pageable = PageRequest.of(0, size);
-    List<Clothes> clothes = clothesRepository.findByOwnerIdPageNation(ownerId, cursor, pageable);
+  public ClothesCursorResponse get(UUID ownerId, UUID cursor, int limit, String typeEqual) {
+    Pageable pageable = PageRequest.of(0, limit);
+
+    ClothesType type = null;
+    if (typeEqual != null && !typeEqual.isEmpty()) {
+      type = ClothesType.valueOf(typeEqual);
+    }
+
+    List<Clothes> clothes = clothesRepository.findByOwnerIdPageNation(ownerId, cursor, type, pageable);
+
+    log.info("조회된 옷 개수: {}, ownerId: {}, type: {}", clothes.size(), ownerId, type);
 
     List<ClothesDto> result = clothesMapper.toDtoList(clothes);
     UUID nextCursor = clothes.isEmpty() ? null : clothes.get(clothes.size() - 1).getId();
 
     ClothesCursorResponse response = new ClothesCursorResponse();
-    response.setClothesDtos(result);
+    response.setData(result);
     response.setNextCursor(nextCursor != null ? nextCursor.toString() : null);
     response.setNextIdAfter(nextCursor != null ? nextCursor.toString() : null);
-    response.setNextCount(result.size());
-    response.setHasNext(result.size() == size);
+    response.setTotalCount(result.size());
+    response.setHasNext(result.size() == limit);
     response.setSortBy("id");
     response.setSortDirection("DESCENDING");
 
@@ -62,7 +64,7 @@ public class ClothesService {
 
   @Transactional(readOnly = true)
   public Clothes getClothesEntityByIdOrThrow(UUID clothesId) {
-	  return clothesRepository.findById(clothesId).orElseThrow(()-> new ClothesNotFoundException());
+    return clothesRepository.findById(clothesId).orElseThrow(()-> new ClothesNotFoundException());
   }
   @Transactional(readOnly = true)
   public Optional<Clothes> getClothesEntityById(UUID clothesId) {
@@ -77,15 +79,16 @@ public class ClothesService {
         .name(request.name())
         .build();
 
-    List<AttributeValue> list = attributeService.createAndReturnList(request.attributes(),clothes);
+    List<AttributeValue> list = attributeService.createAndReturnList(request.attributes(), clothes);
     clothes.setAttributeValues(list);
 
-    if(image!= null && !image.isEmpty()){
-      String url = clothesS3Service.upload(clothes.getId(),image);
-      clothes.setImageUrl(url);
-    }
-
     clothesRepository.save(clothes);
+
+    if(image != null && !image.isEmpty()){
+      String url = clothesS3Service.upload(clothes.getId(), image);
+      clothes.setImageUrl(url);
+      clothesRepository.save(clothes);
+    }
 
     return clothesMapper.toDto(clothes);
   }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/clothes/service/ClothesService.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/clothes/service/ClothesService.java
@@ -135,3 +135,4 @@ public class ClothesService {
   }
 
 }
+

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,37 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: update  # 운영 환경에서는 update 사용
+    show-sql: false
+
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            redirect-uri: "${PROD_DOMAIN:https://otbooteamfive.store}/login/oauth2/code/google"
+          kakao:
+            redirect-uri: "${PROD_DOMAIN:https://otbooteamfive.store}/login/oauth2/code/kakao"
+
+# 로깅 레벨 설정
+logging:
+  level:
+    root: warn
+    org.hibernate.SQL: warn
+    com.part4.team05.sb01otbooteam05: info
+
+# 액츄에이터 보안
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus
+  endpoint:
+    health:
+      show-details: never
+
+app:
+  oauth2:
+    redirect:
+      success-url: "${OAUTH2_SUCCESS_URL:${PROD_DOMAIN:https://otbooteamfive.store}/}"
+      failure-url: "${OAUTH2_FAILURE_URL:${PROD_DOMAIN:https://otbooteamfive.store}/sign-in}"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: sb01-otboo-team05
   profiles:
-    active: prod  #추후에 ALB 도입 고려 후 prod 올릴 예정
+    active: prod  #개발시 dev로 변경필요
   datasource:
     url: ${SPRING_DATASOURCE_URL}
     username: ${SPRING_DATASOURCE_USERNAME}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -116,4 +116,3 @@ admin:
   email: ${ADMIN_EMAIL}
   password: ${ADMIN_PASSWORD}
   name: ${ADMIN_NAME}
-

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: sb01-otboo-team05
   profiles:
-    active: dev  #추후에 ALB 도입 고려 후 prod 올릴 예정
+    active: prod  #추후에 ALB 도입 고려 후 prod 올릴 예정
   datasource:
     url: ${SPRING_DATASOURCE_URL}
     username: ${SPRING_DATASOURCE_USERNAME}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,7 +29,7 @@ spring:
       region:
         static: ap-northeast-2
       s3:
-        bucket: team5-discodeit
+        bucket: team5-otboo
   security:
     oauth2:
       client:
@@ -117,5 +117,4 @@ admin:
   password: ${ADMIN_PASSWORD}
   name: ${ADMIN_NAME}
 
-clothes:
-  bucket: "${CLOTHES_BUCKET}"
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -117,4 +117,3 @@ admin:
   password: ${ADMIN_PASSWORD}
   name: ${ADMIN_NAME}
 
-

--- a/src/test/java/com/part4/team05/sb01otbooteam05/domain/clothes/controller/ClothesControllerTest.java
+++ b/src/test/java/com/part4/team05/sb01otbooteam05/domain/clothes/controller/ClothesControllerTest.java
@@ -1,20 +1,15 @@
 package com.part4.team05.sb01otbooteam05.domain.clothes.controller;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.part4.team05.sb01otbooteam05.config.SecurityConfig;
-import com.part4.team05.sb01otbooteam05.domain.attribute.entity.AttributeValue;
-import com.part4.team05.sb01otbooteam05.domain.attribute.repository.AttributeRepository;
 import com.part4.team05.sb01otbooteam05.domain.attribute.service.AttributeService;
 import com.part4.team05.sb01otbooteam05.domain.auth.security.jwt.JwtTokenProvider;
 import com.part4.team05.sb01otbooteam05.domain.clothes.dto.ClothesCreateRequest;
@@ -23,14 +18,12 @@ import com.part4.team05.sb01otbooteam05.domain.clothes.dto.ClothesDto;
 import com.part4.team05.sb01otbooteam05.domain.clothes.dto.ClothesUpdateRequest;
 import com.part4.team05.sb01otbooteam05.domain.clothes.entity.Clothes;
 import com.part4.team05.sb01otbooteam05.domain.clothes.mapper.ClothesMapper;
-import com.part4.team05.sb01otbooteam05.domain.clothes.repository.ClothesRepository;
 import com.part4.team05.sb01otbooteam05.domain.clothes.service.ClothesService;
 import java.util.Collections;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
@@ -38,10 +31,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.test.web.servlet.RequestBuilder;
-import org.springframework.test.web.servlet.assertj.MockMvcTester.MockMvcRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.web.multipart.MultipartFile;
 
 @WebMvcTest(controllers = ClothesController.class)
 class ClothesControllerTest {
@@ -71,13 +61,53 @@ class ClothesControllerTest {
   void getClothes() throws Exception {
     UUID ownerId = UUID.randomUUID();
 
-    given(clothesService.get(ownerId,null,10)).willReturn(mock(ClothesCursorResponse.class));
+    given(clothesService.get(eq(ownerId), isNull(), eq(10), isNull()))
+        .willReturn(mock(ClothesCursorResponse.class));
 
     mockMvc.perform(MockMvcRequestBuilders
-        .get("/api/clothes")
-        .param("ownerId", ownerId.toString())
-        .with(csrf())
-        .contentType(MediaType.APPLICATION_JSON))
+            .get("/api/clothes")
+            .param("ownerId", ownerId.toString())
+            .param("limit", "10")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser
+  void getClothesWithTypeFilter() throws Exception {
+    UUID ownerId = UUID.randomUUID();
+    String typeEqual = "TOP";
+
+    given(clothesService.get(eq(ownerId), isNull(), eq(10), eq(typeEqual)))
+        .willReturn(mock(ClothesCursorResponse.class));
+
+    mockMvc.perform(MockMvcRequestBuilders
+            .get("/api/clothes")
+            .param("ownerId", ownerId.toString())
+            .param("limit", "10")
+            .param("typeEqual", typeEqual)
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser
+  void getClothesWithCursor() throws Exception {
+    UUID ownerId = UUID.randomUUID();
+    UUID cursor = UUID.randomUUID();
+
+    given(clothesService.get(eq(ownerId), eq(cursor), eq(10), isNull()))
+        .willReturn(mock(ClothesCursorResponse.class));
+
+    mockMvc.perform(MockMvcRequestBuilders
+            .get("/api/clothes")
+            .param("ownerId", ownerId.toString())
+            .param("cursor", cursor.toString())
+            .param("limit", "10")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk());
   }
 
@@ -86,7 +116,7 @@ class ClothesControllerTest {
   void saveClothes() throws Exception {
     UUID ownerId = UUID.randomUUID();
     ClothesCreateRequest request = new ClothesCreateRequest(ownerId,"clothesname1"
-    ,"TOP", Collections.emptyList());
+        ,"TOP", Collections.emptyList());
 
     ClothesDto clothesDto = new ClothesDto();
     clothesDto.setName(request.name());
@@ -103,8 +133,8 @@ class ClothesControllerTest {
     );
 
     MvcResult result = mockMvc.perform(MockMvcRequestBuilders.multipart("/api/clothes")
-        .file( requestPart)
-        .with(csrf()))
+            .file(requestPart)
+            .with(csrf()))
         .andExpect(status().isCreated())
         .andReturn();
 
@@ -124,8 +154,8 @@ class ClothesControllerTest {
     doNothing().when(clothesService).delete(clothesId);
 
     mockMvc.perform(MockMvcRequestBuilders.delete("/api/clothes/"+clothesId)
-        .with(csrf())
-        .contentType(MediaType.APPLICATION_JSON))
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isNoContent());
   }
 
@@ -157,8 +187,6 @@ class ClothesControllerTest {
             }))
         .andExpect(status().isOk())
         .andReturn();
-
-
 
     ClothesDto response = objectMapper.readValue(result.getResponse().getContentAsString()
         ,ClothesDto.class);

--- a/src/test/java/com/part4/team05/sb01otbooteam05/domain/clothes/controller/ClothesControllerTest.java
+++ b/src/test/java/com/part4/team05/sb01otbooteam05/domain/clothes/controller/ClothesControllerTest.java
@@ -195,3 +195,4 @@ class ClothesControllerTest {
     assertEquals(clothesId,response.getId());
   }
 }
+

--- a/src/test/java/com/part4/team05/sb01otbooteam05/domain/clothes/service/ClothesServiceTest.java
+++ b/src/test/java/com/part4/team05/sb01otbooteam05/domain/clothes/service/ClothesServiceTest.java
@@ -26,6 +26,8 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -44,26 +46,54 @@ class ClothesServiceTest {
     AttributeService attributeService;
 
     @Mock
-    JwtTokenProvider jwtTokenProvider;
+    ClothesS3Service clothesS3Service; // 추가
 
     @Test
     void get() {
         UUID ownerId = UUID.randomUUID();
         UUID cursor = UUID.randomUUID();
-        given(clothesRepository.findByOwnerIdPageNation(ownerId, cursor,
-                Pageable.ofSize(10))).willReturn(List.of(mock(Clothes.class)));
+        String typeEqual = "TOP";
+
+        given(clothesRepository.findByOwnerIdPageNation(
+            eq(ownerId),
+            eq(cursor),
+            eq(ClothesType.TOP),
+            any(Pageable.class)
+        )).willReturn(List.of(mock(Clothes.class)));
+
         given(clothesMapper.toDtoList(any(List.class))).willReturn(List.of(mock(ClothesDto.class)));
 
-        ClothesCursorResponse response = clothesService.get(ownerId, cursor, 10);
+        // 수정된 메서드 시그니처 사용
+        ClothesCursorResponse response = clothesService.get(ownerId, cursor, 10, typeEqual);
 
-        assertEquals(1, response.getClothesDtos().size());
+        // 변경된 필드명 사용
+        assertEquals(1, response.getData().size());
+    }
+
+    @Test
+    void get_without_type_filter() {
+        UUID ownerId = UUID.randomUUID();
+        UUID cursor = UUID.randomUUID();
+
+        given(clothesRepository.findByOwnerIdPageNation(
+            eq(ownerId),
+            eq(cursor),
+            isNull(), // type이 null
+            any(Pageable.class)
+        )).willReturn(List.of(mock(Clothes.class)));
+
+        given(clothesMapper.toDtoList(any(List.class))).willReturn(List.of(mock(ClothesDto.class)));
+
+        ClothesCursorResponse response = clothesService.get(ownerId, cursor, 10, null);
+
+        assertEquals(1, response.getData().size());
     }
 
     @Test
     void getClothesEntityByIdOrThrow() {
         UUID clothesId = UUID.randomUUID();
         Clothes clothe = Clothes.builder().id(clothesId)
-                .name("Clothes1").build();
+            .name("Clothes1").build();
 
         given(clothesRepository.findById(clothesId)).willReturn(Optional.ofNullable(clothe));
 
@@ -84,12 +114,12 @@ class ClothesServiceTest {
         UUID ownerId = UUID.randomUUID();
         UUID clothesId = UUID.randomUUID();
         ClothesCreateRequest request = new ClothesCreateRequest(ownerId, "clothes1",
-                "TOP", Collections.emptyList());
+            "TOP", Collections.emptyList());
         Clothes clothes = Clothes.builder()
-                .id(clothesId)
-                .ownerId(ownerId)
-                .name(request.name())
-                .type(ClothesType.valueOf(request.type())).build();
+            .id(clothesId)
+            .ownerId(ownerId)
+            .name(request.name())
+            .type(ClothesType.valueOf(request.type())).build();
 
         ClothesDto dto = new ClothesDto();
         dto.setId(clothesId);
@@ -99,9 +129,9 @@ class ClothesServiceTest {
         given(clothesRepository.save(any(Clothes.class))).willReturn(clothes);
         given(clothesMapper.toDto(any(Clothes.class))).willReturn(dto);
         given(attributeService.createAndReturnList(any(List.class), any(Clothes.class)))
-                .willReturn(Collections.emptyList());
+            .willReturn(Collections.emptyList());
 
-        ClothesDto clothesDto = clothesService.create(request,null);
+        ClothesDto clothesDto = clothesService.create(request, null);
 
         assertEquals(clothesId, clothesDto.getId());
         assertEquals(request.name(), clothesDto.getName());
@@ -110,10 +140,12 @@ class ClothesServiceTest {
     @Test
     void delete() {
         UUID clothesId = UUID.randomUUID();
+        Clothes mockClothes = mock(Clothes.class);
+        given(mockClothes.getImageUrl()).willReturn(null); // 이미지 URL이 없는 경우
+        given(mockClothes.getAttributeValues()).willReturn(Collections.emptyList());
 
         doNothing().when(clothesRepository).delete(any(Clothes.class));
-        given(clothesRepository.findById(clothesId)).willReturn(
-                Optional.ofNullable(mock(Clothes.class)));
+        given(clothesRepository.findById(clothesId)).willReturn(Optional.of(mockClothes));
         doNothing().when(attributeService).delete(any(List.class));
 
         clothesService.delete(clothesId);
@@ -126,12 +158,12 @@ class ClothesServiceTest {
         UUID clothesId = UUID.randomUUID();
 
         ClothesUpdateRequest request = new ClothesUpdateRequest(
-                "clothes2", "BOTTOM", Collections.emptyList());
+            "clothes2", "BOTTOM", Collections.emptyList());
 
         Clothes clothes = Clothes.builder()
-                .id(clothesId)
-                .name("clothes1")
-                .type(ClothesType.valueOf("TOP")).build();
+            .id(clothesId)
+            .name("clothes1")
+            .type(ClothesType.valueOf("TOP")).build();
 
         ClothesDto dto = new ClothesDto();
         dto.setId(clothesId);
@@ -152,7 +184,7 @@ class ClothesServiceTest {
         UUID ownerID = UUID.randomUUID();
 
         given(clothesRepository.findByOwnerId(ownerID))
-                .willReturn(List.of(mock(Clothes.class)));
+            .willReturn(List.of(mock(Clothes.class)));
 
         List<Clothes> clothes = clothesService.findAllByOwnerId(ownerID);
 

--- a/src/test/java/com/part4/team05/sb01otbooteam05/domain/clothes/service/ClothesServiceTest.java
+++ b/src/test/java/com/part4/team05/sb01otbooteam05/domain/clothes/service/ClothesServiceTest.java
@@ -191,3 +191,4 @@ class ClothesServiceTest {
         assertEquals(1, clothes.size());
     }
 }
+


### PR DESCRIPTION
## 🛰️ PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  버그 수정
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🪐 변경 사항
의상 정리 및 배포 관련 얌 파일

## 💬 공유사항 to 리뷰어
알고보니! 그 배포된 부분에서 사진 업로드가 되었던 부분에 대한 궁금증이 아마? 해결된 것 같습니다!
찾아보기론 (정확하지는 않지만) PR을 올리면 자동적으로 빌드가 되고 새로운 태스크 정의를 통해 자동적으로 배포가 되는 상황이라 머지가 되지 않아도 수정내용이 반영이 되어서 생긴 혼란이었습니다! 그래서 옷 부분을 수정하는 게 맞는 거 같아서 재 수정해서 올립니다!
결과적으로 아침에 로컬에서 돌렸을 때 안 돌아가던 게 맞고! 이후 제가 오후에 올렸던 PR이 자동으로 배포가 되어서 배포된 파일에서는 사진업로드가 되었던 것입니다!!


+ 그리고 민주님! 속성 부분이 조회가 안 되고 있는 것 같습니다! 데베 상에서는 존재하는 것으로 보이는데 이 부분이 로직을 통해 화면에 노출되지는 않고 있는 것 같습니다!
<img width="580" height="224" alt="스크린샷 2025-07-29 오전 2 51 02" src="https://github.com/user-attachments/assets/bdffe203-00d8-45f1-9b30-631364cdefaa" />

그리고 지금 아마 배포된 사이트로 소셜로그인 가능하실 것 같아요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **신규 기능**
  * 옷 목록 조회 시 타입별 필터링(typeEqual) 기능이 추가되었습니다.
  * 옷 목록 조회 API의 페이징 파라미터가 개선되어, idAfter(커서)와 limit(개수)로 변경되었습니다.

* **버그 수정**
  * S3 이미지 업로드 및 삭제 시 파일 경로 추출 및 저장 방식이 개선되었습니다.

* **리팩터링**
  * 옷 목록 응답 필드명이 data, totalCount로 변경되었습니다.
  * 쿠키 Secure 속성이 요청 보안 여부에 따라 동적으로 설정되도록 개선되었습니다.
  * 옷 엔티티와 DTO 간 매핑 로직이 향상되어 속성 변환이 명확해졌습니다.

* **문서화**
  * 옷 목록 조회 API 문서가 최신 파라미터와 응답 구조에 맞게 수정되었습니다.

* **테스트**
  * 옷 목록 조회 및 서비스 관련 테스트가 새로운 파라미터와 필터링 로직을 반영하여 보강되었습니다.

* **환경설정**
  * production 환경용 application-prod.yml 파일이 추가되었습니다.
  * S3 버킷 설정이 변경되고, 불필요한 clothes 설정이 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->