### PR TITLE
[#143] dockerfile timezone 서울로 명시

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ FROM amazoncorretto:17-alpine3.17
 WORKDIR /app
 
 COPY app.jar app.jar
-ENV JVM_OPTIONS="-Xms512m -Xmx1024m -XX:+UseG1GC"
+ENV JVM_OPTIONS="-Xms512m -Xmx1024m -XX:+UseG1GC -Duser.timezone=Asia/Seoul"
 
 ENTRYPOINT ["sh", "-c", "java $JVM_OPTIONS -jar app.jar"]


### PR DESCRIPTION
## 🛰️ PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ]  기능 추가
- [ ]  기능 삭제
- [ ]  버그 수정
- [x]  의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🪐 변경 사항

## 💬 공유사항 to 리뷰어



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 컨테이너 내 Java 실행 환경의 기본 시간대를 Asia/Seoul로 설정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->