### PR TITLE
[#155] 배포 환경에서 WebSocket CORS 허용 도메인 누락 수정

### DIFF
--- a/src/main/java/com/part4/team05/sb01otbooteam05/config/WebSocketConfig.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/config/WebSocketConfig.java
@@ -1,5 +1,6 @@
 package com.part4.team05.sb01otbooteam05.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
@@ -10,6 +11,9 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
+    @Value("${websocket.allowed-origins}")
+    private String[] allowedOrigins;
+
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.enableSimpleBroker("/sub", "queue"); // 클라이언트가 구독할 prefix
@@ -19,14 +23,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws") // WebSocket 연결 주소
-                .setAllowedOriginPatterns(getAllowedOrigins())
-                .withSockJS(); // SockJs fallback 지원
-    }
-
-    private String[] getAllowedOrigins() {
-        return new String[] {
-                "https://otbooteamfive.store"
-        };
+        registry.addEndpoint("/ws")
+                // setAllowedOrigins 대신 패턴 기반 허용이 필요하면 setAllowedOriginPatterns 사용 가능
+                .setAllowedOrigins(allowedOrigins)
+                .withSockJS();
     }
 }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/config/WebSocketConfig.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/config/WebSocketConfig.java
@@ -26,7 +26,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private String[] getAllowedOrigins() {
         return new String[] {
-                "http://localhost:3000"
+                "https://otbooteamfive.store"
         };
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -25,3 +25,6 @@ app:
     redirect:
       success-url: "${OAUTH2_SUCCESS_URL:http://localhost:8080/}"
       failure-url: "${OAUTH2_FAILURE_URL:http://localhost:8080/sign-in}"
+
+websocket:
+  allowed-origins: "http://localhost:3000,http://127.0.0.1:3000"

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -35,3 +35,6 @@ app:
     redirect:
       success-url: "${OAUTH2_SUCCESS_URL:${PROD_DOMAIN:https://otbooteamfive.store}/#/}"
       failure-url: "${OAUTH2_FAILURE_URL:${PROD_DOMAIN:https://otbooteamfive.store}/#/sign-in}"
+
+websocket:
+  allowed-origins: "https://otbooteamfive.store"


### PR DESCRIPTION
## 🛰️ PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ]  기능 추가
- [ ]  기능 삭제
- [x]  버그 수정
- [x]  의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🪐 변경 사항
- `WebSocketConfig`의 `setAllowedOriginPatterns()`에 배포 프론트 도메인 추가
- WebSocketConfig 의 setAllowedOriginPatterns()를 ${websocket.allowed-origins} 프로퍼티 주입 방식으로 리팩터링
- application-dev.yml 에 로컬 호스트 정의
- application-prod.yml 에 운영 도메인만 정의

## 💬 공유사항 to 리뷰어
- CORS 허용 도메인을 프로퍼티로 분리해 프로파일별로 관리하도록 변경했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * WebSocket 연결 허용 도메인이 환경별 설정 파일을 통해 관리되도록 개선되었습니다.
  * 개발 환경에서는 "http://localhost:3000"과 "http://127.0.0.1:3000"이 허용되며, 운영 환경에서는 "https://otbooteamfive.store"만 허용됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->