### PR TITLE
[#178] 알림 기능 연동 및 알림 없을 시 빈 리스트 반환

### DIFF
--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/attribute/controller/AttributeController.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/attribute/controller/AttributeController.java
@@ -6,11 +6,14 @@ import com.part4.team05.sb01otbooteam05.domain.attribute.service.AttributeServic
 import com.part4.team05.sb01otbooteam05.domain.attribute.dto.ClothesAttributeDefCreateRequest;
 import com.part4.team05.sb01otbooteam05.domain.attribute.dto.ClothesAttributeDefUpdateRequest;
 import java.util.UUID;
+
+import com.part4.team05.sb01otbooteam05.domain.auth.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.query.SortDirection;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -29,20 +32,23 @@ public class AttributeController implements AttributeControllerDoc{
 
   @PreAuthorize("hasRole('ADMIN')")
   @PostMapping
-  public ResponseEntity<AttributeDefinition> createDef(@RequestBody ClothesAttributeDefCreateRequest request){
-    return ResponseEntity.status(HttpStatus.CREATED).body(attributeService.createDef(request));
+  public ResponseEntity<AttributeDefinition> createDef(@RequestBody ClothesAttributeDefCreateRequest request,
+                                                       @AuthenticationPrincipal CustomUserDetails me){
+    return ResponseEntity.status(HttpStatus.CREATED).body(attributeService.createDef(request, me.getUserId()));
   }
 
   @PreAuthorize("hasRole('ADMIN')")
   @PatchMapping("/{definitionId}")
-  public ResponseEntity<AttributeDefinition> update(@PathVariable UUID definitionId, @RequestBody ClothesAttributeDefUpdateRequest request){
-    return ResponseEntity.ok(attributeService.updateDef(definitionId,request));
+  public ResponseEntity<AttributeDefinition> update(@PathVariable UUID definitionId, @RequestBody ClothesAttributeDefUpdateRequest request,
+                                                    @AuthenticationPrincipal CustomUserDetails me){
+    return ResponseEntity.ok(attributeService.updateDef(definitionId,request, me.getUserId()));
   }
 
   @PreAuthorize("hasRole('ADMIN')")
   @DeleteMapping("/{definitionId}")
-  public ResponseEntity<Void> deleteDef(@PathVariable UUID definitionId){
-    attributeService.deleteDef(definitionId);
+  public ResponseEntity<Void> deleteDef(@PathVariable UUID definitionId,
+                                        @AuthenticationPrincipal CustomUserDetails me){
+    attributeService.deleteDef(definitionId, me.getUserId());
     return ResponseEntity.noContent().build();
   }
 

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/attribute/controller/AttributeControllerDoc.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/attribute/controller/AttributeControllerDoc.java
@@ -4,6 +4,7 @@ import com.part4.team05.sb01otbooteam05.domain.attribute.dto.ClothesAttributeDef
 import com.part4.team05.sb01otbooteam05.domain.attribute.entity.AttributeDefinition;
 import com.part4.team05.sb01otbooteam05.domain.attribute.dto.ClothesAttributeDefCreateRequest;
 import com.part4.team05.sb01otbooteam05.domain.attribute.dto.ClothesAttributeDefUpdateRequest;
+import com.part4.team05.sb01otbooteam05.domain.auth.security.CustomUserDetails;
 import com.part4.team05.sb01otbooteam05.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -14,6 +15,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -41,7 +43,8 @@ public interface AttributeControllerDoc {
       )
   })
   ResponseEntity<AttributeDefinition> createDef(
-      @Parameter(description = "의상 속성 정의 등록 요청") @RequestBody ClothesAttributeDefCreateRequest request
+      @Parameter(description = "의상 속성 정의 등록 요청") @RequestBody ClothesAttributeDefCreateRequest request,
+      @AuthenticationPrincipal CustomUserDetails me
   );
 
   @Operation(
@@ -63,7 +66,8 @@ public interface AttributeControllerDoc {
   })
   ResponseEntity<AttributeDefinition> update(
       @Parameter(description = "definitionId") @PathVariable UUID definitionId,
-      @Parameter(description = "의상 속성 정의 수정 요청") @RequestBody ClothesAttributeDefUpdateRequest request
+      @Parameter(description = "의상 속성 정의 수정 요청") @RequestBody ClothesAttributeDefUpdateRequest request,
+      @AuthenticationPrincipal CustomUserDetails me
   );
 
   @Operation(
@@ -80,7 +84,8 @@ public interface AttributeControllerDoc {
       )
   })
   ResponseEntity<Void> deleteDef(
-      @Parameter(description = "definitionId") @PathVariable UUID definitionId
+      @Parameter(description = "definitionId") @PathVariable UUID definitionId,
+      @AuthenticationPrincipal CustomUserDetails me
   );
 
   @Operation(

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/attribute/service/AttributeService.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/attribute/service/AttributeService.java
@@ -114,7 +114,7 @@ public class AttributeService {
     notificationService.createAndSendNotification(
             userId,
             "의상 속성이 변경되었어요.",
-            "[" + name + "] 속성이 확인해보세요.",
+            "[" + name + "] 속성을 확인해보세요.",
             NotificationLevel.INFO
     );
   }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/attribute/service/AttributeService.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/attribute/service/AttributeService.java
@@ -16,6 +16,9 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import com.part4.team05.sb01otbooteam05.domain.notification.entity.NotificationLevel;
+import com.part4.team05.sb01otbooteam05.domain.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.query.SortDirection;
 import org.springframework.data.domain.PageRequest;
@@ -29,6 +32,7 @@ public class AttributeService {
   private final AttributeRepository attributeRepository;
   private final AttributeDefinitionRepository definitionRepository;
   private final AttributeDefinitionMapper definitionMapper;
+  private final NotificationService notificationService;
 
   @Transactional
   public List<AttributeValue> createAndReturnList(List<ClothesAttributeDto> attributes, Clothes clothes){
@@ -60,7 +64,7 @@ public class AttributeService {
   }
 
   @Transactional
-  public AttributeDefinition createDef(ClothesAttributeDefCreateRequest request){
+  public AttributeDefinition createDef(ClothesAttributeDefCreateRequest request, UUID userId){
       AttributeDefinition attributeDefinition = AttributeDefinition.builder()
           .name(request.name())
           .selectableValues(request.selectableValues())
@@ -68,23 +72,51 @@ public class AttributeService {
 
       definitionRepository.save(attributeDefinition);
 
+    // 알림 전송
+    notificationService.createAndSendNotification(
+            userId,
+            "새로운 의상 속성이 추가되었어요.",
+            "내 의상에 [" + request.name() + "] 속성을 추가해보세요.",
+            NotificationLevel.INFO
+    );
+
       return attributeDefinition;
   }
 
   @Transactional
-  public AttributeDefinition updateDef(UUID definitionId,ClothesAttributeDefUpdateRequest request){
+  public AttributeDefinition updateDef(UUID definitionId,ClothesAttributeDefUpdateRequest request, UUID userId){
     AttributeDefinition attributeDefinition = definitionRepository.findById(definitionId)
         .orElseThrow(() -> new NoSuchDefException("해당하는 속성이 없습니다."));
 
     attributeDefinition.setName(request.name());
     attributeDefinition.setSelectableValues(request.selectableValues());
 
+    notificationService.createAndSendNotification(
+            userId,
+            "의상 속성이 변경되었어요.",
+            "[" + request.name() + "] 속성을 확인해보세요.",
+            NotificationLevel.INFO
+    );
+
     return attributeDefinition;
   }
 
   @Transactional
-  public void deleteDef(UUID definitionId){
+  public void deleteDef(UUID definitionId, UUID userId){
+
+    AttributeDefinition definition = definitionRepository.findById(definitionId)
+            .orElseThrow(() -> new NoSuchDefException("해당하는 속성이 없습니다."));
+
+    String name = definition.getName();
+
     definitionRepository.deleteById(definitionId);
+
+    notificationService.createAndSendNotification(
+            userId,
+            "의상 속성이 변경되었어요.",
+            "[" + name + "] 속성이 확인해보세요.",
+            NotificationLevel.INFO
+    );
   }
 
   public ClothesAttributeDefDtoCursorResponse getDef(

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/feed/service/BasicFeedService.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/feed/service/BasicFeedService.java
@@ -15,6 +15,9 @@ import com.part4.team05.sb01otbooteam05.domain.feed.repository.SearchFeedReposit
 import com.part4.team05.sb01otbooteam05.domain.feedComment.repository.FeedCommentRepository;
 import com.part4.team05.sb01otbooteam05.domain.feedLike.entity.FeedLike;
 import com.part4.team05.sb01otbooteam05.domain.feedLike.repository.FeedLikeRepository;
+import com.part4.team05.sb01otbooteam05.domain.follow.service.FollowService;
+import com.part4.team05.sb01otbooteam05.domain.notification.entity.NotificationLevel;
+import com.part4.team05.sb01otbooteam05.domain.notification.service.NotificationService;
 import com.part4.team05.sb01otbooteam05.domain.ootd.entity.Ootd;
 import com.part4.team05.sb01otbooteam05.domain.user.entity.User;
 import com.part4.team05.sb01otbooteam05.domain.user.service.UserService;
@@ -25,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -43,6 +47,8 @@ public class BasicFeedService implements FeedService {
     private final FeedCommentRepository feedCommentRepository;
     private final FeedMapper feedMapper;
     private final SearchFeedRepository searchFeedRepository;
+    private final NotificationService notificationService;
+    private final FollowService followService;
 
     @Override
     @Transactional(readOnly = true)
@@ -80,8 +86,31 @@ public class BasicFeedService implements FeedService {
             throw new IllegalArgumentException();
         }
 
-        log.info("피드 생성 성공: feedId={}", newFeed.getId());
-        return feedMapper.toFeedDto(newFeed, 0L, 0, false);
+        Feed savedFeed = feedRepository.save(newFeed);
+
+        log.info("피드 생성 성공: feedId={}", savedFeed.getId());
+
+        // 팔로우한 사용자가 피드를 등록하면 알림 전송
+        try {
+            List<UUID> followerIds = followService.getFollowers(userId, null, 1000, null)
+                    .data()
+                    .stream()
+                    .map(f -> f.follower().userId())
+                    .toList();
+
+            for (UUID followerId : followerIds) {
+                notificationService.createAndSendNotification(
+                        followerId,
+                        "새로운 피드",
+                        user.getName() + "님이 피드를 등록했습니다.",
+                        NotificationLevel.INFO
+                );
+            }
+        } catch (Exception e) {
+            log.warn("피드 등록 알림 전송 실패: userId={}", userId, e);
+        }
+
+        return feedMapper.toFeedDto(savedFeed, 0L, 0, false);
     }
 
     // 피드 삭제

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/feed/service/BasicFeedService.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/feed/service/BasicFeedService.java
@@ -154,6 +154,21 @@ public class BasicFeedService implements FeedService {
         if (!isLikeExistent) {
             feedLikeRepository.save(new FeedLike(feed, author));
             currentLikeCount++; // 좋아요 수 1 증가
+
+            // 내 피드에 좋아요 등록 알림
+            try {
+                UUID receiverId = feed.getAuthor().getId();
+                if (!receiverId.equals(userId)) {
+                    notificationService.createAndSendNotification(
+                            receiverId,
+                            "좋아요 알림",
+                            author.getName() + "님이 내 피드에 좋아요를 눌렀습니다.",
+                            NotificationLevel.INFO
+                    );
+                }
+            } catch (Exception e) {
+                log.warn("좋아요 알림 전송 실패: userId={}, feedId={}", userId, feedId, e);
+            }
         }
 
         // 5. 피드 Dto 반환

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/feed/service/BasicFeedService.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/feed/service/BasicFeedService.java
@@ -110,7 +110,7 @@ public class BasicFeedService implements FeedService {
             log.warn("피드 등록 알림 전송 실패: userId={}", userId, e);
         }
 
-        return feedMapper.toFeedDto(newFeed, 0L, 0, false);
+        return feedMapper.toFeedDto(savedFeed, 0L, 0, false);
     }
 
     // 피드 삭제

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/feed/service/BasicFeedService.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/feed/service/BasicFeedService.java
@@ -88,7 +88,28 @@ public class BasicFeedService implements FeedService {
 
         Feed savedFeed = feedRepository.save(newFeed);
 
-        log.info("피드 생성 성공: feedId={}", newFeed.getId());
+        log.info("피드 생성 성공: feedId={}", savedFeed.getId());
+
+        // 팔로우한 사용자가 피드를 등록하면 알림 전송
+        try {
+            List<UUID> followerIds = followService.getFollowers(userId, null, 1000, null)
+                    .data()
+                    .stream()
+                    .map(f -> f.follower().userId())
+                    .toList();
+
+            for (UUID followerId : followerIds) {
+                notificationService.createAndSendNotification(
+                        followerId,
+                        "새로운 피드",
+                        user.getName() + "님이 피드를 등록했습니다.",
+                        NotificationLevel.INFO
+                );
+            }
+        } catch (Exception e) {
+            log.warn("피드 등록 알림 전송 실패: userId={}", userId, e);
+        }
+
         return feedMapper.toFeedDto(newFeed, 0L, 0, false);
     }
 

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/feedComment/service/BasicFeedCommentService.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/feedComment/service/BasicFeedCommentService.java
@@ -2,6 +2,8 @@ package com.part4.team05.sb01otbooteam05.domain.feedComment.service;
 
 import java.util.UUID;
 
+import com.part4.team05.sb01otbooteam05.domain.notification.entity.NotificationLevel;
+import com.part4.team05.sb01otbooteam05.domain.notification.service.NotificationService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,6 +34,7 @@ public class BasicFeedCommentService implements FeedCommentService {
 	private final UserService userService;
 	private final CommentMapper commentMapper;
 	private final FeedCommentRepository feedCommentRepository;
+	private final NotificationService notificationService;
 
 	@Override
 	@Transactional(readOnly = true)
@@ -52,6 +55,21 @@ public class BasicFeedCommentService implements FeedCommentService {
 		// 2. 댓글 생성
 		Comment newComment = new Comment(feed, author, request.content());
 		feedCommentRepository.save(newComment);
+
+		// 내 피드에 댓글 등록 알림
+		try {
+			UUID receiverId = feed.getAuthor().getId();
+			if (!receiverId.equals(userId)) {
+				notificationService.createAndSendNotification(
+						receiverId,
+						"댓글 알림",
+						author.getName() + "님이 내 피드에 댓글을 달았습니다.",
+						NotificationLevel.INFO
+				);
+			}
+		} catch (Exception e) {
+			log.warn("댓글 알림 전송 실패: userId={}, feedId={}, commentId={}", userId, feedId, newComment.getId(), e);
+		}
 
 		// 3. 댓글 Dto 반환
 		log.info("댓글 생성 성공: commentId={}", newComment.getId());

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/notification/service/impl/NotificationServiceImpl.java
@@ -53,8 +53,17 @@ public class NotificationServiceImpl implements NotificationService {
 
         List<Notification> results = notificationRepository.findNotifications(userId, idAfter, pageable);
 
-        if (cursor == null && idAfter == null && results.isEmpty()) {
-            throw new OtbooException(ErrorCode.NOTIFICATION_NOT_FOUND);
+        if (results.isEmpty() && idAfter == null) {
+            log.info("userId={}에 대한 알림이 존재하지 않습니다.", userId);
+            return new NotificationDtoCursorResponse(
+                    Collections.emptyList(),
+                    null,
+                    null,
+                    false,
+                    0L,
+                    "createdAt",
+                    "DESC"
+            );
         }
 
         boolean hasNext = results.size() > limit;

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/service/AdminServiceImpl.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/service/AdminServiceImpl.java
@@ -2,6 +2,8 @@ package com.part4.team05.sb01otbooteam05.domain.user.service;
 
 import com.part4.team05.sb01otbooteam05.domain.auth.repository.RefreshTokenRepository;
 import com.part4.team05.sb01otbooteam05.domain.auth.security.CustomUserDetails;
+import com.part4.team05.sb01otbooteam05.domain.notification.entity.NotificationLevel;
+import com.part4.team05.sb01otbooteam05.domain.notification.service.NotificationService;
 import com.part4.team05.sb01otbooteam05.domain.user.dto.UserDto;
 import com.part4.team05.sb01otbooteam05.domain.user.dto.UserDtoCursorResponse;
 import com.part4.team05.sb01otbooteam05.domain.user.dto.UserLockUpdateRequest;
@@ -33,6 +35,7 @@ public class AdminServiceImpl implements AdminService {
 
   private final UserRepository userRepository;
   private final RefreshTokenRepository refreshTokenRepository;
+  private final NotificationService notificationService;
 
   // 슈퍼 어드민 판별 헬퍼 메서드
   private boolean isSuperAdmin(User user) {
@@ -189,6 +192,14 @@ public class AdminServiceImpl implements AdminService {
 
     refreshTokenRepository.revokeAllByUserId(userId);
     log.info("권한 변경 완료 및 강제 로그아웃 처리: userId={}", userId);
+
+    // 권한 변경 알림 전송
+    notificationService.createAndSendNotification(
+            updatedUser.getId(),
+            "권한이 변경되었습니다",
+            "관리자에 의해 귀하의 권한이 " + request.role().name() + "(으)로 변경되었습니다.",
+            NotificationLevel.INFO
+    );
 
     return UserDto.from(updatedUser);
   }

--- a/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/service/AdminServiceImpl.java
+++ b/src/main/java/com/part4/team05/sb01otbooteam05/domain/user/service/AdminServiceImpl.java
@@ -194,12 +194,16 @@ public class AdminServiceImpl implements AdminService {
     log.info("권한 변경 완료 및 강제 로그아웃 처리: userId={}", userId);
 
     // 권한 변경 알림 전송
-    notificationService.createAndSendNotification(
-            updatedUser.getId(),
-            "권한이 변경되었습니다",
-            "관리자에 의해 귀하의 권한이 " + request.role().name() + "(으)로 변경되었습니다.",
-            NotificationLevel.INFO
-    );
+     try {
+       notificationService.createAndSendNotification(
+               updatedUser.getId(),
+               "권한이 변경되었습니다",
+               "관리자에 의해 귀하의 권한이 " + request.role().name() + "(으)로 변경되었습니다.",
+               NotificationLevel.INFO
+       );
+     } catch (Exception e) {
+       log.warn("권한 변경 알림 전송 실패: userId={}", updatedUser.getId(), e);
+     }
 
     return UserDto.from(updatedUser);
   }

--- a/src/test/java/com/part4/team05/sb01otbooteam05/domain/attribute/controller/AttributeControllerTest.java
+++ b/src/test/java/com/part4/team05/sb01otbooteam05/domain/attribute/controller/AttributeControllerTest.java
@@ -6,28 +6,23 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.part4.team05.sb01otbooteam05.config.SecurityConfig;
 import com.part4.team05.sb01otbooteam05.domain.attribute.dto.ClothesAttributeDefDtoCursorResponse;
 import com.part4.team05.sb01otbooteam05.domain.attribute.entity.AttributeDefinition;
-import com.part4.team05.sb01otbooteam05.domain.attribute.mapper.AttributeDefinitionMapper;
-import com.part4.team05.sb01otbooteam05.domain.attribute.repository.AttributeDefinitionRepository;
 import com.part4.team05.sb01otbooteam05.domain.attribute.service.AttributeService;
 import com.part4.team05.sb01otbooteam05.domain.attribute.dto.ClothesAttributeDefCreateRequest;
 import com.part4.team05.sb01otbooteam05.domain.attribute.dto.ClothesAttributeDefUpdateRequest;
+import com.part4.team05.sb01otbooteam05.domain.auth.security.CustomUserDetails;
 import com.part4.team05.sb01otbooteam05.domain.auth.security.jwt.JwtTokenProvider;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -56,16 +51,22 @@ class AttributeControllerTest {
 
   @Test
   @DisplayName("속성 추가 성공 테스트")
-  @WithMockUser(roles = "ADMIN")
   void createDefSuccess() throws Exception{
     ClothesAttributeDefCreateRequest request = new ClothesAttributeDefCreateRequest("test1",
         List.of("a","b","c"));
 
+    CustomUserDetails customUserDetails = new CustomUserDetails(
+            UUID.randomUUID(),
+            "admin@otboo.com",
+            "ADMIN"
+    );
+
     mockMvc.perform(MockMvcRequestBuilders.post("/api/clothes/attribute-defs")
-            .content(objectMapper.writeValueAsString(request))
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(csrf()))
-        .andExpect(status().isCreated());
+                    .with(csrf())
+                    .with(user(customUserDetails))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isCreated());
   }
 
   @Test
@@ -82,23 +83,26 @@ class AttributeControllerTest {
   }
 
   @Test
-  @WithMockUser(roles = "ADMIN")
   @DisplayName("속성 업데이트 성공 테스트")
   void updateSuccess() throws Exception {
-    AttributeDefinition attributeDefinition = mock(AttributeDefinition.class);
+    UUID id = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
 
     ClothesAttributeDefUpdateRequest request = new ClothesAttributeDefUpdateRequest("test1",
         List.of("d","e","f"));
 
-    UUID id = UUID.randomUUID();
+    AttributeDefinition mockDefinition = mock(AttributeDefinition.class);
 
-    given(attributeService.updateDef(id,request)).willReturn(attributeDefinition);
+    given(attributeService.updateDef(eq(id), eq(request), eq(userId))).willReturn(mockDefinition);
 
-    mockMvc.perform(MockMvcRequestBuilders.patch("/api/clothes/attribute-defs/"+ id)
-        .content(objectMapper.writeValueAsString(request))
-        .contentType(MediaType.APPLICATION_JSON)
-            .with(csrf()))
-        .andExpect(status().isOk());
+    CustomUserDetails customUserDetails = new CustomUserDetails(userId, "admin@otboo.com", "ADMIN");
+
+    mockMvc.perform(MockMvcRequestBuilders.patch("/api/clothes/attribute-defs/" + id)
+                    .with(csrf())
+                    .with(user(customUserDetails))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk());
   }
 
   @Test
@@ -111,7 +115,8 @@ class AttributeControllerTest {
         List.of("d","e","f"));
 
     UUID id = UUID.randomUUID();
-    given(attributeService.updateDef(id,request)).willReturn(attributeDefinition);
+    given(attributeService.updateDef(eq(id), eq(request), any(UUID.class)))
+            .willReturn(attributeDefinition);
 
     mockMvc.perform(MockMvcRequestBuilders.patch("/api/clothes/attribute-defs/"+ id)
             .content(objectMapper.writeValueAsString(request))
@@ -120,14 +125,19 @@ class AttributeControllerTest {
   }
 
   @Test
-  @WithMockUser(roles = "ADMIN")
   @DisplayName("속성 삭제 성공 테스트")
   void deleteDef() throws Exception {
-    doNothing().when(attributeService).deleteDef(any(UUID.class));
+    UUID id = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+
+    CustomUserDetails customUserDetails = new CustomUserDetails(userId, "admin@otboo.com", "ADMIN");
+
+    doNothing().when(attributeService).deleteDef(eq(id), any(UUID.class));
 
     mockMvc.perform(MockMvcRequestBuilders
             .delete("/api/clothes/attribute-defs/"+ UUID.randomUUID())
-            .with(csrf()))
+            .with(csrf())
+            .with(user(customUserDetails)))
         .andExpect(status().isNoContent());
   }
 

--- a/src/test/java/com/part4/team05/sb01otbooteam05/domain/attribute/service/AttributeServiceTest.java
+++ b/src/test/java/com/part4/team05/sb01otbooteam05/domain/attribute/service/AttributeServiceTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.part4.team05.sb01otbooteam05.config.SecurityConfig;
 import com.part4.team05.sb01otbooteam05.domain.attribute.dto.ClothesAttributeDefCreateRequest;
 import com.part4.team05.sb01otbooteam05.domain.attribute.dto.ClothesAttributeDefDto;
 import com.part4.team05.sb01otbooteam05.domain.attribute.dto.ClothesAttributeDefDtoCursorResponse;
@@ -26,14 +25,13 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+
+import com.part4.team05.sb01otbooteam05.domain.notification.service.NotificationService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.Pageable;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -52,6 +50,9 @@ class AttributeServiceTest {
 
   @Mock
   JwtTokenProvider jwtTokenProvider;
+
+  @Mock
+  NotificationService notificationService;
 
   @Test
   void createAndReturnList() {
@@ -110,11 +111,17 @@ class AttributeServiceTest {
         .selectableValues(Collections.emptyList())
         .build();
 
+    UUID userId = UUID.randomUUID();
+
+    doNothing().when(notificationService).createAndSendNotification(
+            any(), any(), any(), any()
+    );
+
     given(attributeDefinitionRepository.save(any(AttributeDefinition.class)))
         .willReturn(savedDefinition);
 
     AttributeDefinition definition=
-        attributeService.createDef(request);
+        attributeService.createDef(request,userId);
 
     assertEquals("name1",definition.getName());
   }
@@ -123,6 +130,7 @@ class AttributeServiceTest {
   void updateDef() {
 
     UUID id = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
 
     ClothesAttributeDefUpdateRequest request = new ClothesAttributeDefUpdateRequest("name1"
     ,List.of("test1"));
@@ -130,10 +138,14 @@ class AttributeServiceTest {
     AttributeDefinition attributeDefinition = AttributeDefinition.builder().id(id)
         .name("test2").build();
 
+    doNothing().when(notificationService).createAndSendNotification(
+            any(), any(), any(), any()
+    );
+
     given(attributeDefinitionRepository.findById(id)).willReturn(
         Optional.ofNullable(attributeDefinition));
 
-    AttributeDefinition definition = attributeService.updateDef(id,request);
+    AttributeDefinition definition = attributeService.updateDef(id,request,userId);
 
     assertEquals("name1",definition.getName());
     assertEquals(List.of("test1"),definition.getSelectableValues());
@@ -142,10 +154,19 @@ class AttributeServiceTest {
   @Test
   void deleteDef() {
     UUID id = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+
+    AttributeDefinition definition = AttributeDefinition.builder()
+            .id(id)
+            .name("test")
+            .selectableValues(List.of("a", "b"))
+            .build();
+
+    given(attributeDefinitionRepository.findById(id)).willReturn(Optional.of(definition));
 
     doNothing().when(attributeDefinitionRepository).deleteById(id);
 
-    attributeService.deleteDef(id);
+    attributeService.deleteDef(id,userId);
 
     verify(attributeDefinitionRepository, times(1))
         .deleteById(any(UUID.class));

--- a/src/test/java/com/part4/team05/sb01otbooteam05/domain/notification/NotificationServiceImplTest.java
+++ b/src/test/java/com/part4/team05/sb01otbooteam05/domain/notification/NotificationServiceImplTest.java
@@ -52,11 +52,16 @@ class NotificationServiceImplTest {
         when(user.getId()).thenReturn(userId);
         when(notificationRepository.findNotifications(eq(userId), isNull(), any(Pageable.class)))
                 .thenReturn(Collections.emptyList());
-        OtbooException ex = assertThrows(OtbooException.class,
-                () -> service.getNotifications(user, /*cursor=*/null, /*idAfter=*/null, /*limit=*/5)
-        );
-        assertEquals(ErrorCode.NOTIFICATION_NOT_FOUND, ex.getErrorCode());
+
+        NotificationDtoCursorResponse response = service.getNotifications(user, null, null, 5);
+
+        assertNotNull(response);
+        assertEquals(0, response.data().size());
+        assertFalse(response.hasNext());
+        assertNull(response.nextIdAfter());
+        assertNull(response.nextCursor());
     }
+
 
     @Test
     void testGetNotificationsNoNext() {

--- a/src/test/java/com/part4/team05/sb01otbooteam05/domain/user/service/AdminServiceImplTest.java
+++ b/src/test/java/com/part4/team05/sb01otbooteam05/domain/user/service/AdminServiceImplTest.java
@@ -2,6 +2,7 @@ package com.part4.team05.sb01otbooteam05.domain.user.service;
 
 import com.part4.team05.sb01otbooteam05.domain.auth.repository.RefreshTokenRepository;
 import com.part4.team05.sb01otbooteam05.domain.auth.security.CustomUserDetails;
+import com.part4.team05.sb01otbooteam05.domain.notification.service.NotificationService;
 import com.part4.team05.sb01otbooteam05.domain.user.dto.UserDto;
 import com.part4.team05.sb01otbooteam05.domain.user.dto.UserDtoCursorResponse;
 import com.part4.team05.sb01otbooteam05.domain.user.dto.UserLockUpdateRequest;
@@ -45,6 +46,7 @@ class AdminServiceImplTest {
   @Mock private SecurityContext securityContext;
   @Mock private Authentication authentication;
   @Mock private CustomUserDetails userDetails;
+  @Mock private NotificationService notificationService;
   @InjectMocks private AdminServiceImpl adminService;
 
   private User testUser;


### PR DESCRIPTION
## 🛰️ PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ]  기능 추가
- [ ]  기능 삭제
- [x]  버그 수정
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🪐 변경 사항
- 알림 없을 시 빈 리스트 반환
- 권한 변경 시 알림 연동
- 의상 속성 추가 시 알림 연동
- 내 피드에 좋아요 또는 댓글 등록 시 알림 연동
- 팔로우한 사용자가 피드를 등록 시 알림 연동

## 💬 공유사항 to 리뷰어



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 의류 속성 정의 생성, 수정, 삭제 시 사용자에게 알림이 전송됩니다.
  * 피드 작성 시 팔로워들에게 새 피드 알림이 발송됩니다.
  * 피드에 좋아요 또는 댓글 작성 시 피드 작성자에게 알림이 전송됩니다.
  * 관리자가 사용자 권한을 변경하면 해당 사용자에게 알림이 전송됩니다.

* **버그 수정**
  * 사용자의 알림이 없을 때 예외 대신 빈 결과를 반환하도록 개선되었습니다.

* **테스트**
  * 알림 기능 추가에 따른 테스트 코드가 보완되고, 사용자 인증 정보 처리 방식이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->